### PR TITLE
[feat] #4 마이페이지 유저 프로필 조회 API 기능 구현

### DIFF
--- a/src/main/java/com/ggang/be/api/user/controller/UserController.java
+++ b/src/main/java/com/ggang/be/api/user/controller/UserController.java
@@ -10,7 +10,6 @@ import com.ggang.be.api.facade.SignupRequestFacade;
 import com.ggang.be.api.user.NicknameValidator;
 import com.ggang.be.api.user.dto.*;
 import com.ggang.be.api.user.service.UserService;
-import com.ggang.be.domain.user.dto.UserSchoolDto;
 import com.ggang.be.global.jwt.JwtService;
 import com.ggang.be.global.jwt.TokenVo;
 import com.ggang.be.global.util.LengthValidator;
@@ -66,12 +65,23 @@ public class UserController {
   
     @GetMapping("/user/home/profile")
     public ResponseEntity<ApiResponse<UserSchoolResponseDto>> getGroupInfo(
-            @RequestHeader("Authorization") final String accessToken
+            @RequestHeader("Authorization") String accessToken
     ) {
         Long userId = jwtService.parseTokenAndGetUserId(accessToken);
-        UserSchoolDto userSchoolDto = userService.getUserSchoolById(userId);
 
-        return ResponseBuilder.ok(UserSchoolResponseDto.of(userSchoolDto));
+        return ResponseBuilder.ok(
+                UserSchoolResponseDto.of(userService.getUserSchoolById(userId))
+        );
+    }
+
+    @GetMapping("/user/my/profile")
+    public ResponseEntity<ApiResponse<UserProfileResponse>> getUserProfile(
+            @RequestHeader("Authorization") String accessToken
+    ) {
+        Long userId = jwtService.parseTokenAndGetUserId(accessToken);
+        return ResponseBuilder.ok(
+                UserProfileResponse.of(userService.getUserInfoById(userId))
+        );
     }
 
     @PatchMapping("/reissue/token")
@@ -82,7 +92,7 @@ public class UserController {
 
     @PostMapping("/login")
     public ResponseEntity<ApiResponse<TokenVo>> login(
-            @RequestHeader(value = "Authorization") String authorization,
+            @RequestHeader("Authorization") String authorization,
             @RequestBody final LoginRequest request
     ) {
         log.info("소셜 로그인 요청 - Platform: {}, Code: {}", request.getPlatform(), authorization);

--- a/src/main/java/com/ggang/be/api/user/dto/UserProfileResponse.java
+++ b/src/main/java/com/ggang/be/api/user/dto/UserProfileResponse.java
@@ -1,0 +1,19 @@
+package com.ggang.be.api.user.dto;
+
+import com.ggang.be.domain.user.dto.UserProfile;
+
+public record UserProfileResponse(
+        String nickname,
+        String schoolName,
+        String majorName,
+        int profileImg
+) {
+    public static UserProfileResponse of(UserProfile userProfile) {
+        return new UserProfileResponse(
+                userProfile.nickname(),
+                userProfile.schoolName(),
+                userProfile.schoolMajor(),
+                userProfile.profileImg()
+        );
+    }
+}

--- a/src/main/java/com/ggang/be/api/user/service/UserService.java
+++ b/src/main/java/com/ggang/be/api/user/service/UserService.java
@@ -3,6 +3,7 @@ package com.ggang.be.api.user.service;
 import com.ggang.be.domain.constant.Platform;
 import com.ggang.be.domain.user.UserEntity;
 import com.ggang.be.domain.user.dto.SaveUserSignUp;
+import com.ggang.be.domain.user.dto.UserProfile;
 import com.ggang.be.domain.user.dto.UserSchoolDto;
 
 import java.util.Optional;
@@ -11,6 +12,8 @@ public interface UserService {
     UserEntity getUserById(Long userId);
 
     UserSchoolDto getUserSchoolById(Long userId);
+
+    UserProfile getUserInfoById(Long userId);
 
     boolean duplicateCheckNickname(String nickname);
 
@@ -23,5 +26,4 @@ public interface UserService {
     boolean findByPlatformAndPlatformId(Platform platform, String platformId);
 
     Optional<Long> getUserIdByPlatformAndPlatformId(Platform platform, String platformId);
-
 }

--- a/src/main/java/com/ggang/be/domain/user/application/UserServiceImpl.java
+++ b/src/main/java/com/ggang/be/domain/user/application/UserServiceImpl.java
@@ -6,6 +6,7 @@ import com.ggang.be.api.user.service.UserService;
 import com.ggang.be.domain.constant.Platform;
 import com.ggang.be.domain.user.UserEntity;
 import com.ggang.be.domain.user.dto.SaveUserSignUp;
+import com.ggang.be.domain.user.dto.UserProfile;
 import com.ggang.be.domain.user.dto.UserSchoolDto;
 import com.ggang.be.domain.user.infra.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -36,6 +37,13 @@ public class UserServiceImpl implements UserService {
                 .orElseThrow(() -> new GongBaekException(ResponseError.USER_NOT_FOUND));
 
         return new UserSchoolDto(nickname, schoolName);
+    }
+
+    @Override
+    public UserProfile getUserInfoById(Long userId) {
+        return UserProfile.of(userRepository.findById(userId)
+                .orElseThrow(() -> new GongBaekException(ResponseError.USER_NOT_FOUND))
+        );
     }
 
     @Override

--- a/src/main/java/com/ggang/be/domain/user/dto/UserProfile.java
+++ b/src/main/java/com/ggang/be/domain/user/dto/UserProfile.java
@@ -1,0 +1,19 @@
+package com.ggang.be.domain.user.dto;
+
+import com.ggang.be.domain.user.UserEntity;
+
+public record UserProfile(
+        String nickname,
+        String schoolName,
+        String schoolMajor,
+        int profileImg
+) {
+    public static UserProfile of(UserEntity userEntity) {
+        return new UserProfile(
+                userEntity.getNickname(),
+                userEntity.getSchool().getSchoolName(),
+                userEntity.getSchoolMajorName(),
+                userEntity.getProfileImg()
+        );
+    }
+}


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### #️⃣관련 이슈
- #4 

### 🎋 작업중인 브랜치
- feat/#4

### 💡 작업내용
- 마이페이지 화면의 유저 프로필 조회 API 기능을 구현합니다.
<img width="200" alt="image" src="https://github.com/user-attachments/assets/fc5a30ea-d091-4dd6-86e4-7b8a7cdb5980" />

### 🔑 주요 변경사항
- 프로필 사진, 닉네임, 학교, 학과 조회
**Response Body**
```json
{
    "success": true,
    "code": 2000,
    "message": "성공하였습니다.",
    "data": {
        "nickname": "개죽이이",
        "schoolName": "가톨릭대학교",
        "majorName": "미디어기술콘텐츠학과",
        "profileImg": 1
    }
}
```

### 🏞 스크린샷
<img width="467" alt="image" src="https://github.com/user-attachments/assets/ead7a54a-01fb-4c7e-9010-fa27fe54a620" />

closes #4 