### PR TITLE
[fix] #7 소개글의 최소 글자수 제한 삭제

### DIFF
--- a/src/main/java/com/ggang/be/api/user/NicknameValidator.java
+++ b/src/main/java/com/ggang/be/api/user/NicknameValidator.java
@@ -12,7 +12,7 @@ public class NicknameValidator {
     private static final Pattern koreanPattern = Pattern.compile("^[가-힣]+$");
 
     public static void validate(String nickname){
-        if(!LengthValidator.rangelengthCheck(nickname, MIN_LENGTH, MAX_LENGTH))
+        if(!LengthValidator.rangeLengthCheck(nickname, MIN_LENGTH, MAX_LENGTH))
             throw new GongBaekException(ResponseError.BAD_REQUEST);
         if(!koreanPattern.matcher(nickname).find())
             throw new GongBaekException(ResponseError.BAD_REQUEST);

--- a/src/main/java/com/ggang/be/api/user/controller/UserController.java
+++ b/src/main/java/com/ggang/be/api/user/controller/UserController.java
@@ -30,12 +30,12 @@ public class UserController {
     private final SignupRequestFacade signupRequestFacade;
     private final JwtService jwtService;
 
-    private final static int INTRODUCTION_MIN_LENGTH = 20;
+    private final static int INTRODUCTION_MIN_LENGTH = 0;
     private final static int INTRODUCTION_MAX_LENGTH = 100;
 
     @PostMapping("/user/validate/introduction")
     public ResponseEntity<ApiResponse<Void>> validateIntroduction(@RequestBody final ValidIntroductionRequest dto) {
-        if(LengthValidator.rangelengthCheck(dto.introduction(), INTRODUCTION_MIN_LENGTH, INTRODUCTION_MAX_LENGTH))
+        if(LengthValidator.rangeLengthCheck(dto.introduction(), INTRODUCTION_MIN_LENGTH, INTRODUCTION_MAX_LENGTH))
             return ResponseBuilder.ok(null);
         throw new GongBaekException(ResponseError.INVALID_INPUT_LENGTH);
     }

--- a/src/main/java/com/ggang/be/domain/group/IntroductionValidator.java
+++ b/src/main/java/com/ggang/be/domain/group/IntroductionValidator.java
@@ -4,13 +4,12 @@ import com.ggang.be.api.common.ResponseError;
 import com.ggang.be.api.exception.GongBaekException;
 import com.ggang.be.global.util.LengthValidator;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Component;
 
 @Slf4j
 public class IntroductionValidator {
     public static void isIntroductionValid(String introduction) {
         log.info("now value is : {}", introduction);
-        if(!LengthValidator.rangelengthCheck(introduction, 20, 100)) {
+        if (!LengthValidator.rangeLengthCheck(introduction, 0, 100)) {
             log.error("소개글 길이 검증에 실패하였습니다.");
             throw new GongBaekException(ResponseError.BAD_REQUEST);
         }

--- a/src/main/java/com/ggang/be/domain/group/LocationValidator.java
+++ b/src/main/java/com/ggang/be/domain/group/LocationValidator.java
@@ -20,7 +20,7 @@ public class LocationValidator {
             log.error("그룹 장소글 패턴 검증에 실패하였습니다.");
             throw new GongBaekException(ResponseError.BAD_REQUEST);
         }
-        if(!LengthValidator.rangelengthCheck(value, 2, 20)) {
+        if (!LengthValidator.rangeLengthCheck(value, 2, 20)) {
             log.error("그룹 장소글 길이 검증에 실패하였습니다.");
             throw new GongBaekException(ResponseError.BAD_REQUEST);
         }

--- a/src/main/java/com/ggang/be/domain/group/TitleValidator.java
+++ b/src/main/java/com/ggang/be/domain/group/TitleValidator.java
@@ -16,7 +16,7 @@ public class TitleValidator {
             log.error("그룹 제목에 엔터가 들어갔습니다.");
             throw new GongBaekException(ResponseError.BAD_REQUEST);
         }
-        if(!LengthValidator.rangelengthCheck(title, 2, 20)) {
+        if(!LengthValidator.rangeLengthCheck(title, 2, 20)) {
             log.error("그룹 제목 길이 검증에 실패하였습니다.");
             throw new GongBaekException(ResponseError.BAD_REQUEST);
         }

--- a/src/main/java/com/ggang/be/global/util/LengthValidator.java
+++ b/src/main/java/com/ggang/be/global/util/LengthValidator.java
@@ -9,7 +9,7 @@ import java.util.regex.Pattern;
 public class LengthValidator {
     private final static Pattern emojiPattern = Pattern.compile("\\X");
 
-    public static boolean rangelengthCheck(final String value, final int minLength, final int maxLength){
+    public static boolean rangeLengthCheck(final String value, final int minLength, final int maxLength){
         Matcher matcher = emojiPattern.matcher(value);
         long count = matcher.results().count();
         log.info("now value is : {}", value);

--- a/src/test/java/com/ggang/be/global/util/LengthValidatorTest.java
+++ b/src/test/java/com/ggang/be/global/util/LengthValidatorTest.java
@@ -1,7 +1,5 @@
 package com.ggang.be.global.util;
 
-import static org.junit.jupiter.api.Assertions.*;
-
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -17,7 +15,7 @@ class LengthValidatorTest {
         int minLength = 3;
         int maxLength = 7;
         //when & then
-        Assertions.assertThat(LengthValidator.rangelengthCheck(testCase, minLength, maxLength)).isTrue();
+        Assertions.assertThat(LengthValidator.rangeLengthCheck(testCase, minLength, maxLength)).isTrue();
     }
 
     @ParameterizedTest
@@ -28,7 +26,7 @@ class LengthValidatorTest {
         int minLength = 3;
         int maxLength = 7;
         //when & then
-        Assertions.assertThat(LengthValidator.rangelengthCheck(testCase, minLength, maxLength)).isFalse();
+        Assertions.assertThat(LengthValidator.rangeLengthCheck(testCase, minLength, maxLength)).isFalse();
     }
 
     @ParameterizedTest


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### #️⃣관련 이슈
- #7 

### 🎋 작업중인 브랜치
- fix/#7

### 💡 작업내용
- 회원가입, 모임 생성 시 사용하는 API 에서 소개글의 최소 글자수 제한을 삭제합니다.

### 🔑 주요 변경사항
- 기존 API
최소 20자 ~ 최대 100자

- 변경 API
최소 0자 ~ 최대 100자

- **UserController.java**
```java
    private final static int INTRODUCTION_MIN_LENGTH = 0;
    private final static int INTRODUCTION_MAX_LENGTH = 100;

    @PostMapping("/user/validate/introduction")
    public ResponseEntity<ApiResponse<Void>> validateIntroduction(@RequestBody final ValidIntroductionRequest dto) {
        if(LengthValidator.rangeLengthCheck(dto.introduction(), INTRODUCTION_MIN_LENGTH, INTRODUCTION_MAX_LENGTH))
            return ResponseBuilder.ok(null);
        throw new GongBaekException(ResponseError.INVALID_INPUT_LENGTH);
    }

```

- **IntroductionValidator.java**
```java
@Slf4j
public class IntroductionValidator {
    public static void isIntroductionValid(String introduction) {
        log.info("now value is : {}", introduction);
        if (!LengthValidator.rangeLengthCheck(introduction, 0, 100)) {
            log.error("소개글 길이 검증에 실패하였습니다.");
            throw new GongBaekException(ResponseError.BAD_REQUEST);
        }
    }
}
```

### 🏞 스크린샷
<img width="561" alt="image" src="https://github.com/user-attachments/assets/879173d2-01a6-457b-825d-0b2fbc2a09e6" />

closes #7 
