### PR TITLE
[feat] 로그아웃 API 기능 구현

### DIFF
--- a/src/main/java/com/ggang/be/api/facade/LoginFacade.java
+++ b/src/main/java/com/ggang/be/api/facade/LoginFacade.java
@@ -26,13 +26,21 @@ public class LoginFacade {
                 .orElseGet(() -> createTemporaryToken(platformId));
     }
 
+    @Transactional
+    public void logout(Long userId) {
+        userService.removeRefreshToken(userId);
+    }
+
     public String getPlatformId(Platform platform, String authorization) {
         return platformAuthService.getPlatformId(platform, authorization);
     }
 
     private TokenVo login(Long userId) {
         log.info("기존 유저 로그인 성공 - userId: {}", userId);
-        return new TokenVo(userId, jwtService.createAccessToken(userId), jwtService.createRefreshToken(userId));
+        String newRefreshToken = jwtService.createRefreshToken(userId);
+
+        userService.updateRefreshToken(newRefreshToken, userService.getUserById(userId));
+        return new TokenVo(userId, jwtService.createAccessToken(userId), newRefreshToken);
     }
 
     private TokenVo createTemporaryToken(String platformId) {

--- a/src/main/java/com/ggang/be/api/user/controller/UserController.java
+++ b/src/main/java/com/ggang/be/api/user/controller/UserController.java
@@ -107,6 +107,19 @@ public class UserController {
                 .orElseGet(() -> ResponseBuilder.created(loginFacade.login(platformId, request.getPlatform())));
     }
 
+    @DeleteMapping("/logout")
+    public ResponseEntity<ApiResponse<Void>> logout(
+            @RequestHeader("Authorization") String accessToken
+    ) {
+        log.info("logout authorization: {}", accessToken);
+
+        long userId = jwtService.parseTokenAndGetUserId(accessToken);
+        log.info("logout userId: {}", userId);
+
+        loginFacade.logout(userId);
+        return ResponseBuilder.ok(null);
+    }
+
     @PostMapping("/emails/verification-requests")
     public ResponseEntity<ApiResponse<Void>> sendMessage(
             @RequestParam("email") String email,

--- a/src/main/java/com/ggang/be/api/user/service/UserService.java
+++ b/src/main/java/com/ggang/be/api/user/service/UserService.java
@@ -28,4 +28,6 @@ public interface UserService {
     Optional<Long> getUserIdByPlatformAndPlatformId(Platform platform, String platformId);
 
     void checkDuplicatedEmail(String email);
+
+    void removeRefreshToken(Long userId);
 }

--- a/src/main/java/com/ggang/be/domain/user/application/UserServiceImpl.java
+++ b/src/main/java/com/ggang/be/domain/user/application/UserServiceImpl.java
@@ -105,5 +105,14 @@ public class UserServiceImpl implements UserService {
             throw new GongBaekException(ResponseError.USERNAME_ALREADY_EXISTS);
         }
     }
+
+    @Override
+    @Transactional
+    public void removeRefreshToken(Long userId) {
+        UserEntity user = userRepository.findById(userId)
+                .orElseThrow(() -> new GongBaekException(ResponseError.USER_NOT_FOUND));
+
+        user.updateRefreshToken(null);
+    }
 }
 

--- a/src/main/java/com/ggang/be/global/jwt/JwtService.java
+++ b/src/main/java/com/ggang/be/global/jwt/JwtService.java
@@ -98,7 +98,12 @@ public class JwtService {
         try {
             String splitToken = token.split(" ")[1];
             SecretKey secretKey = getSecretKey();
-            return parseTokenAndGetUserId(secretKey, splitToken);
+            Long userId = parseTokenAndGetUserId(secretKey, splitToken);
+
+            if (userService.getUserById(userId).getRefreshToken() == null) {
+                throw new GongBaekException(ResponseError.INVALID_TOKEN);
+            }
+            return userId;
         } catch (JwtException | NumberFormatException e) {
             log.error("JWT parsing error : {}", e.getMessage());
             throw new GongBaekException(ResponseError.INVALID_TOKEN);

--- a/src/test/java/com/ggang/be/global/jwt/JwtServiceTest.java
+++ b/src/test/java/com/ggang/be/global/jwt/JwtServiceTest.java
@@ -47,20 +47,20 @@ public class JwtServiceTest {
         Long userId = 1L;
 
         String token = Jwts.builder()
-            .subject(userId.toString())
-            .expiration(new Date(System.currentTimeMillis() + 1000 * 60 * 60 * 24 * 7))
-            .claim("userId", userId)
-            .signWith(secretKey)
-            .compact();
+                .subject(userId.toString())
+                .expiration(new Date(System.currentTimeMillis() + 1000 * 60 * 60 * 24 * 7))
+                .claim("userId", userId)
+                .signWith(secretKey)
+                .compact();
 
-            //when && then
-            Jws<Claims> x = Jwts.parser().verifyWith(secretKey).build()
-                    .parseSignedClaims(token);
-                String parsedUserId = x.getPayload().get("userId").toString();
+        //when && then
+        Jws<Claims> x = Jwts.parser().verifyWith(secretKey).build()
+                .parseSignedClaims(token);
+        String parsedUserId = x.getPayload().get("userId").toString();
         Date expiration = x.getPayload().getExpiration();
         Assertions.assertThat(expiration).isAfter(new Date());
         Assertions.assertThat(Long.parseLong(parsedUserId)).isEqualTo(userId);
-        }
+    }
 
     @Test
     @DisplayName("토큰 재발급 테스트")
@@ -70,20 +70,21 @@ public class JwtServiceTest {
         SecretKey secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
         Long userId = 1L;
         UserEntity fixture = UserEntityFixture.create();
+        fixture.updateRefreshToken("mockedRefreshToken");
 
         Date date = new Date(System.currentTimeMillis() + 86400000000L);
         String token = Jwts.builder()
-            .subject(userId.toString())
-            .expiration(date)
-            .claim("userId", userId)
-            .signWith(secretKey)
-            .compact();
+                .subject(userId.toString())
+                .expiration(date)
+                .claim("userId", userId)
+                .signWith(secretKey)
+                .compact();
 
         when(jwtProperties.getKey()).thenReturn(secret);
         when(userService.getUserById(userId)).thenReturn(fixture);
         doNothing().when(userService).validateRefreshToken(fixture, token);
 
-       String accessToken = jwtService.createAccessToken(userId);
+        String accessToken = jwtService.createAccessToken(userId);
         String refreshToken = jwtService.createRefreshToken(userId);
         String addBearerPrefix = "Bearer " + token;
 


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### #️⃣관련 이슈
- #15 

### 🎋 작업중인 브랜치
- feat/#15

### 💡 작업내용
- 로그아웃 API 를 구현했습니다.

### 🔑 주요 변경사항
- 로그아웃 시 리프레시 토큰 삭제
- 로그인할 때 새로 발급한 리프레시 토큰 저장

### 🏞 스크린샷
![image](https://github.com/user-attachments/assets/e3f8fb1b-b875-4e9f-991c-09d2bb4aa374)

closes #15
