### PR TITLE
[fix] #23 인증코드 redis -> caffeine 으로 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,6 +75,10 @@ dependencies {
 
     // redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    // caffeine
+    implementation 'com.github.ben-manes.caffeine:caffeine'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/ggang/be/api/email/service/AuthCodeCacheService.java
+++ b/src/main/java/com/ggang/be/api/email/service/AuthCodeCacheService.java
@@ -1,0 +1,49 @@
+package com.ggang.be.api.email.service;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class AuthCodeCacheService {
+
+    private Cache<String, String> authCodeCache;
+    private final EmailProperties emailProperties;
+
+    @PostConstruct
+    public void init() {
+        long expirationMillis = emailProperties.getAuthCodeExpirationMillis();
+        log.info("AuthCodeCache time: {}ms", expirationMillis);
+
+        this.authCodeCache = Caffeine.newBuilder()
+                .expireAfterWrite(Duration.ofMillis(expirationMillis))
+                .maximumSize(10000)
+                .build();
+    }
+
+    public void saveAuthCode(String email, String authCode) {
+        authCodeCache.put(email, authCode);
+    }
+
+    public String getAuthCode(String email) {
+        return authCodeCache.getIfPresent(email);
+    }
+
+    public boolean verifyCode(String email, String code) {
+        String storedCode = authCodeCache.getIfPresent(email);
+        return storedCode != null && storedCode.equals(code);
+    }
+
+    public void removeCode(String email) {
+        authCodeCache.invalidate(email);
+    }
+}

--- a/src/main/java/com/ggang/be/api/facade/MailFacade.java
+++ b/src/main/java/com/ggang/be/api/facade/MailFacade.java
@@ -1,52 +1,49 @@
 package com.ggang.be.api.facade;
 
 import com.ggang.be.api.common.ResponseError;
-import com.ggang.be.api.email.service.EmailProperties;
+import com.ggang.be.api.email.service.AuthCodeCacheService;
 import com.ggang.be.api.email.service.MailService;
 import com.ggang.be.api.exception.GongBaekException;
 import com.ggang.be.api.school.service.SchoolService;
 import com.ggang.be.api.user.service.UserService;
-import com.ggang.be.infra.redis.RedisService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
-import java.time.Duration;
 import java.util.Arrays;
 
 @Component
 @RequiredArgsConstructor
 @Slf4j
 public class MailFacade {
-    private final EmailProperties emailProperties;
     private final UserService userService;
     private final MailService mailService;
     private final SchoolService schoolService;
-    private final RedisService redisService;
+    private final AuthCodeCacheService authCodeCacheService;
 
-    private static final String AUTH_CODE_PREFIX = "AuthCode ";
     private static final String EMAIL_TITLE = "공백 학교 이메일 인증 안내";
 
     public void sendCodeToEmail(String toEmail, String schoolName) {
         userService.checkDuplicatedEmail(toEmail);
         verifyDomain(toEmail, schoolName);
-        String authCode = mailService.createCode();
-        mailService.sendEmail(toEmail, EMAIL_TITLE, authCode);
 
-        redisService.saveValue(AUTH_CODE_PREFIX + toEmail,
-                authCode, Duration.ofMillis(emailProperties.getAuthCodeExpirationMillis()));
+        String authCode = mailService.createCode();
+        authCodeCacheService.saveAuthCode(toEmail, authCode);
+
+        mailService.sendEmail(toEmail, EMAIL_TITLE, authCode);
     }
 
     public void verifiedCode(String email, String schoolName, String authCode) {
         userService.checkDuplicatedEmail(email);
-        String redisKey = AUTH_CODE_PREFIX + email;
-        String redisAuthCode = redisService.getValue(redisKey);
-
         verifyDomain(email, schoolName);
 
-        if (redisAuthCode == null || !redisService.checkExistsValue(redisKey) || !redisAuthCode.equals(authCode)) {
+        String cachedAuthCode = authCodeCacheService.getAuthCode(email);
+
+        if (cachedAuthCode == null || !cachedAuthCode.equals(authCode)) {
             throw new GongBaekException(ResponseError.INVALID_INPUT_VALUE);
         }
+
+        authCodeCacheService.removeCode(email);
     }
 
     private void verifyDomain(String email, String schoolName) {

--- a/src/test/java/com/ggang/be/api/facade/MailFacadeTest.java
+++ b/src/test/java/com/ggang/be/api/facade/MailFacadeTest.java
@@ -50,7 +50,7 @@ class MailFacadeTest {
         schoolDomainMap.put("가톨릭대학교", "catholic");
         schoolDomainMap.put("건국대학교", "konkuk");
 
-        when(emailProperties.getAuthCodeExpirationMillis()).thenReturn(1800000L);
+        lenient().when(emailProperties.getAuthCodeExpirationMillis()).thenReturn(1800000L);
     }
 
     @Test

--- a/src/test/java/com/ggang/be/api/facade/MailFacadeTest.java
+++ b/src/test/java/com/ggang/be/api/facade/MailFacadeTest.java
@@ -1,12 +1,12 @@
 package com.ggang.be.api.facade;
 
 import com.ggang.be.api.common.ResponseError;
+import com.ggang.be.api.email.service.AuthCodeCacheService;
 import com.ggang.be.api.email.service.EmailProperties;
 import com.ggang.be.api.email.service.MailService;
 import com.ggang.be.api.exception.GongBaekException;
 import com.ggang.be.api.school.service.SchoolService;
 import com.ggang.be.api.user.service.UserService;
-import com.ggang.be.infra.redis.RedisService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -18,7 +18,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class MailFacadeTest {
@@ -36,7 +36,7 @@ class MailFacadeTest {
     private SchoolService schoolService;
 
     @Mock
-    private RedisService redisService;
+    private AuthCodeCacheService authCodeCacheService;
 
     @InjectMocks
     private MailFacade mailFacade;
@@ -49,6 +49,8 @@ class MailFacadeTest {
         schoolDomainMap.put("홍익대학교", "hongik");
         schoolDomainMap.put("가톨릭대학교", "catholic");
         schoolDomainMap.put("건국대학교", "konkuk");
+
+        when(emailProperties.getAuthCodeExpirationMillis()).thenReturn(1800000L);
     }
 
     @Test
@@ -59,8 +61,7 @@ class MailFacadeTest {
 
         // Mock 설정
         when(schoolService.findSchoolDomainByName(schoolName)).thenReturn(schoolDomainMap.get(schoolName));
-        when(redisService.getValue("AuthCode " + email)).thenReturn(authCode);
-        when(redisService.checkExistsValue("AuthCode " + email)).thenReturn(true);
+        when(authCodeCacheService.getAuthCode(email)).thenReturn(authCode);
 
         // 정상 검증 테스트 (예외가 발생하지 않아야 함)
         mailFacade.verifiedCode(email, schoolName, authCode);
@@ -74,8 +75,7 @@ class MailFacadeTest {
 
         // Mock 설정
         when(schoolService.findSchoolDomainByName(schoolName)).thenReturn(schoolDomainMap.get(schoolName));
-        when(redisService.getValue("AuthCode " + email)).thenReturn(authCode);
-        when(redisService.checkExistsValue("AuthCode " + email)).thenReturn(true);
+        when(authCodeCacheService.getAuthCode(email)).thenReturn(authCode);
 
         // 정상 검증 테스트 (예외가 발생하지 않아야 함)
         mailFacade.verifiedCode(email, schoolName, authCode);
@@ -89,8 +89,7 @@ class MailFacadeTest {
 
         // Mock 설정
         when(schoolService.findSchoolDomainByName(schoolName)).thenReturn(schoolDomainMap.get(schoolName));
-        when(redisService.getValue("AuthCode " + email)).thenReturn(authCode);
-        when(redisService.checkExistsValue("AuthCode " + email)).thenReturn(true);
+        when(authCodeCacheService.getAuthCode(email)).thenReturn(authCode);
 
         // 정상 검증 테스트 (예외가 발생하지 않아야 함)
         mailFacade.verifiedCode(email, schoolName, authCode);
@@ -120,8 +119,7 @@ class MailFacadeTest {
 
         // Mock 설정
         when(schoolService.findSchoolDomainByName(schoolName)).thenReturn(schoolDomainMap.get(schoolName));
-        when(redisService.getValue("AuthCode " + email)).thenReturn(wrongAuthCode);
-        when(redisService.checkExistsValue("AuthCode " + email)).thenReturn(true);
+        when(authCodeCacheService.getAuthCode(email)).thenReturn(wrongAuthCode);
 
         // 인증 코드 불일치 예외 테스트
         assertThatThrownBy(() -> mailFacade.verifiedCode(email, schoolName, authCode))


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### #️⃣관련 이슈
- #23 

### 🎋 작업중인 브랜치
- fix/#23

### 🤔 고민한 내용
- 인증 로직의 특성상, 짧은 TTL(3~5분) 후 삭제되는 휘발성 데이터만 관리하면 되므로 분산 환경에서의 Redis 수준 확장성까지는 필요하지 않다고 판단했습니다.
- Caffeine은 JVM 메모리 기반으로 동작하므로 네트워크 오버헤드가 없고, TTL과 만료 정책을 세밀하게 설정할 수 있어 단순 인증 코드 관리에 적합하다고 생각했습니다.

### 💡 작업내용
- 인증코드 인증 및 전송 방식 redis -> caffeine 으로 변경
- 테스트 환경 및 로컬 개발 환경에서 Redis 의존성 제거

### 🔑 주요 변경사항
- 인증코드 redis -> caffeine 으로 변경
```java
public void sendCodeToEmail(String toEmail, String schoolName) {
        userService.checkDuplicatedEmail(toEmail);
        verifyDomain(toEmail, schoolName);

        String authCode = mailService.createCode();
        authCodeCacheService.saveAuthCode(toEmail, authCode);

        mailService.sendEmail(toEmail, EMAIL_TITLE, authCode);
    }
```

### 🏞 스크린샷
<img width="300" alt="image" src="https://github.com/user-attachments/assets/682254c0-816f-4c5b-9eac-6e0a4395e5b4" />

closes #23
