### PR TITLE
[feat] #21 회원탈퇴 API 기능 구현

### DIFF
--- a/src/main/java/com/ggang/be/api/comment/service/CommentService.java
+++ b/src/main/java/com/ggang/be/api/comment/service/CommentService.java
@@ -12,4 +12,7 @@ public interface CommentService {
     void deleteComment(final long commentId);
 
     CommentEntity findById(long commentId);
+
+    @Transactional
+    void removeCommentAuthor(long userId);
 }

--- a/src/main/java/com/ggang/be/api/common/ResponseError.java
+++ b/src/main/java/com/ggang/be/api/common/ResponseError.java
@@ -52,6 +52,7 @@ public enum ResponseError {
     TIME_SLOT_ALREADY_EXIST(4095, "이미 해당 시간표에는 강의 시간표가 존재합니다." ),
     APPLY_ALREADY_EXIST(4096, "이미 신청한 유저입니다."),
     GROUP_ALREADY_FULL(4097, "이미 인원이 마감된 모임입니다."),
+    GROUP_ALREADY_CLOSED(4098, "해당 모임은 종료되었습니다."),
 
     // 500 Internal Server Error
     INTERNAL_SERVER_ERROR(5000, "서버 내부 오류입니다."),

--- a/src/main/java/com/ggang/be/api/gongbaekTimeSlot/service/GongbaekTimeSlotService.java
+++ b/src/main/java/com/ggang/be/api/gongbaekTimeSlot/service/GongbaekTimeSlotService.java
@@ -6,4 +6,6 @@ import com.ggang.be.domain.user.UserEntity;
 
 public interface GongbaekTimeSlotService {
     GongbaekTimeSlotEntity registerGongbaekTimeSlot(UserEntity userEntity, GongbaekTimeSlotRequest dto);
+
+    void removeGongbaekTimeSlotUser(long userId);
 }

--- a/src/main/java/com/ggang/be/api/group/dto/GroupResponse.java
+++ b/src/main/java/com/ggang/be/api/group/dto/GroupResponse.java
@@ -2,10 +2,12 @@ package com.ggang.be.api.group.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.ggang.be.domain.constant.Category;
+import com.ggang.be.domain.constant.Status;
 import com.ggang.be.domain.constant.WeekDay;
 
 public record GroupResponse(
         long groupId,
+        Status status,
         String groupType,
         String groupTitle,
         String location,

--- a/src/main/java/com/ggang/be/api/group/everyGroup/service/EveryGroupService.java
+++ b/src/main/java/com/ggang/be/api/group/everyGroup/service/EveryGroupService.java
@@ -30,6 +30,8 @@ public interface EveryGroupService {
 
     void deleteGroupHost(UserEntity currentUser);
 
+    void modifyGroupStatus(UserEntity currentUser);
+
     ReadEveryGroup getActiveEveryGroups(UserEntity currentUser, Category category);
 
     void validateApplyEveryGroup(UserEntity currentUser, EveryGroupEntity everyGroupEntity);

--- a/src/main/java/com/ggang/be/api/group/everyGroup/service/EveryGroupService.java
+++ b/src/main/java/com/ggang/be/api/group/everyGroup/service/EveryGroupService.java
@@ -28,6 +28,8 @@ public interface EveryGroupService {
 
     void deleteEveryGroup(UserEntity currentUser, EveryGroupEntity everyGroupEntity);
 
+    void deleteGroupHost(UserEntity currentUser);
+
     ReadEveryGroup getActiveEveryGroups(UserEntity currentUser, Category category);
 
     void validateApplyEveryGroup(UserEntity currentUser, EveryGroupEntity everyGroupEntity);

--- a/src/main/java/com/ggang/be/api/group/everyGroup/strategy/ApplyEveryGroupStrategy.java
+++ b/src/main/java/com/ggang/be/api/group/everyGroup/strategy/ApplyEveryGroupStrategy.java
@@ -5,6 +5,7 @@ import com.ggang.be.api.exception.GongBaekException;
 import com.ggang.be.api.group.dto.GroupRequest;
 import com.ggang.be.api.group.everyGroup.service.EveryGroupService;
 import com.ggang.be.api.group.registry.ApplyGroupStrategy;
+import com.ggang.be.api.group.validator.GroupValidator;
 import com.ggang.be.api.lectureTimeSlot.service.LectureTimeSlotService;
 import com.ggang.be.api.userEveryGroup.service.UserEveryGroupService;
 import com.ggang.be.domain.common.SameSchoolValidator;
@@ -21,6 +22,7 @@ import lombok.RequiredArgsConstructor;
 public class ApplyEveryGroupStrategy implements ApplyGroupStrategy {
 
     private final EveryGroupService everyGroupService;
+    private final GroupValidator groupValidator;
     private final SameSchoolValidator sameSchoolValidator;
     private final UserEveryGroupService userEveryGroupService;
     private final LectureTimeSlotService lectureTimeSlotService;
@@ -33,6 +35,7 @@ public class ApplyEveryGroupStrategy implements ApplyGroupStrategy {
     @Override
     public void applyGroup(UserEntity findUserEntity, GroupRequest request) {
         EveryGroupEntity everyGroupEntity = everyGroupService.findEveryGroupEntityByGroupId(request.groupId());
+        groupValidator.isValidEveryGroup(everyGroupEntity);
         sameSchoolValidator.isUserReadMySchoolEveryGroup(findUserEntity, everyGroupEntity);
         everyGroupService.validateApplyEveryGroup(findUserEntity, everyGroupEntity);
         GroupVo groupVo = GroupVo.fromEveryGroup(EveryGroupVo.of(everyGroupEntity));

--- a/src/main/java/com/ggang/be/api/group/everyGroup/strategy/CancelEveryGroupStrategy.java
+++ b/src/main/java/com/ggang/be/api/group/everyGroup/strategy/CancelEveryGroupStrategy.java
@@ -5,6 +5,7 @@ import com.ggang.be.api.exception.GongBaekException;
 import com.ggang.be.api.group.dto.GroupRequest;
 import com.ggang.be.api.group.everyGroup.service.EveryGroupService;
 import com.ggang.be.api.group.registry.CancelGroupStrategy;
+import com.ggang.be.api.group.validator.GroupValidator;
 import com.ggang.be.api.userEveryGroup.service.UserEveryGroupService;
 import com.ggang.be.domain.constant.GroupType;
 import com.ggang.be.domain.group.everyGroup.EveryGroupEntity;
@@ -17,6 +18,7 @@ import lombok.RequiredArgsConstructor;
 public class CancelEveryGroupStrategy implements CancelGroupStrategy {
     private final EveryGroupService everyGroupService;
     private final UserEveryGroupService userEveryGroupService;
+    private final GroupValidator groupValidator;
 
     @Override
     public boolean support(GroupType groupType) {
@@ -26,6 +28,7 @@ public class CancelEveryGroupStrategy implements CancelGroupStrategy {
     @Override
     public void cancelGroup(UserEntity userEntity, GroupRequest request) {
         EveryGroupEntity everyGroupEntity = everyGroupService.findEveryGroupEntityByGroupId(request.groupId());
+        groupValidator.isValidEveryGroup(everyGroupEntity);
         if (everyGroupService.validateCancelEveryGroup(userEntity, everyGroupEntity))
             userEveryGroupService.cancelEveryGroup(userEntity, everyGroupEntity);
         else throw new GongBaekException(ResponseError.GROUP_CANCEL_NOT_FOUND);

--- a/src/main/java/com/ggang/be/api/group/onceGroup/service/OnceGroupService.java
+++ b/src/main/java/com/ggang/be/api/group/onceGroup/service/OnceGroupService.java
@@ -28,6 +28,8 @@ public interface OnceGroupService {
 
     void deleteOnceGroup(UserEntity currentUser, OnceGroupEntity onceGroupEntity);
 
+    void deleteGroupHost(UserEntity currentUser);
+
     ReadOnceGroup getActiveOnceGroups(UserEntity currentUser, Category category);
 
     void validateApplyOnceGroup(UserEntity currentUser, OnceGroupEntity onceGroupEntity);

--- a/src/main/java/com/ggang/be/api/group/onceGroup/service/OnceGroupService.java
+++ b/src/main/java/com/ggang/be/api/group/onceGroup/service/OnceGroupService.java
@@ -30,6 +30,8 @@ public interface OnceGroupService {
 
     void deleteGroupHost(UserEntity currentUser);
 
+    void modifyGroupStatus(UserEntity currentUser);
+
     ReadOnceGroup getActiveOnceGroups(UserEntity currentUser, Category category);
 
     void validateApplyOnceGroup(UserEntity currentUser, OnceGroupEntity onceGroupEntity);

--- a/src/main/java/com/ggang/be/api/group/onceGroup/strategy/ApplyOnceGroupStrategy.java
+++ b/src/main/java/com/ggang/be/api/group/onceGroup/strategy/ApplyOnceGroupStrategy.java
@@ -5,6 +5,7 @@ import com.ggang.be.api.exception.GongBaekException;
 import com.ggang.be.api.group.dto.GroupRequest;
 import com.ggang.be.api.group.onceGroup.service.OnceGroupService;
 import com.ggang.be.api.group.registry.ApplyGroupStrategy;
+import com.ggang.be.api.group.validator.GroupValidator;
 import com.ggang.be.api.lectureTimeSlot.service.LectureTimeSlotService;
 import com.ggang.be.api.userOnceGroup.service.UserOnceGroupService;
 import com.ggang.be.domain.common.SameSchoolValidator;
@@ -21,6 +22,7 @@ import lombok.RequiredArgsConstructor;
 public class ApplyOnceGroupStrategy implements ApplyGroupStrategy {
 
     private final OnceGroupService onceGroupService;
+    private final GroupValidator groupValidator;
     private final SameSchoolValidator sameSchoolValidator;
     private final UserOnceGroupService userOnceGroupService;
     private final LectureTimeSlotService lectureTimeSlotService;
@@ -33,6 +35,7 @@ public class ApplyOnceGroupStrategy implements ApplyGroupStrategy {
     @Override
     public void applyGroup(UserEntity findUserEntity, GroupRequest request) {
         OnceGroupEntity onceGroupEntity = onceGroupService.findOnceGroupEntityByGroupId(request.groupId());
+        groupValidator.isValidOnceGroup(onceGroupEntity);
         sameSchoolValidator.isUserReadMySchoolOnceGroup(findUserEntity, onceGroupEntity);
         onceGroupService.validateApplyOnceGroup(findUserEntity, onceGroupEntity);
         GroupVo groupVo = GroupVo.fromOnceGroup(OnceGroupVo.of(onceGroupEntity));

--- a/src/main/java/com/ggang/be/api/group/onceGroup/strategy/CancelOnceGroupStrategy.java
+++ b/src/main/java/com/ggang/be/api/group/onceGroup/strategy/CancelOnceGroupStrategy.java
@@ -5,6 +5,7 @@ import com.ggang.be.api.exception.GongBaekException;
 import com.ggang.be.api.group.dto.GroupRequest;
 import com.ggang.be.api.group.onceGroup.service.OnceGroupService;
 import com.ggang.be.api.group.registry.CancelGroupStrategy;
+import com.ggang.be.api.group.validator.GroupValidator;
 import com.ggang.be.api.userOnceGroup.service.UserOnceGroupService;
 import com.ggang.be.domain.constant.GroupType;
 import com.ggang.be.domain.group.onceGroup.OnceGroupEntity;
@@ -17,6 +18,7 @@ import lombok.RequiredArgsConstructor;
 public class CancelOnceGroupStrategy implements CancelGroupStrategy {
     private final OnceGroupService onceGroupService;
     private final UserOnceGroupService userOnceGroupService;
+    private final GroupValidator groupValidator;
 
     @Override
     public boolean support(GroupType groupType) {
@@ -26,6 +28,7 @@ public class CancelOnceGroupStrategy implements CancelGroupStrategy {
     @Override
     public void cancelGroup(UserEntity userEntity, GroupRequest request) {
         OnceGroupEntity onceGroupEntity = onceGroupService.findOnceGroupEntityByGroupId(request.groupId());
+        groupValidator.isValidOnceGroup(onceGroupEntity);
         if (onceGroupService.validateCancelOnceGroup(userEntity, onceGroupEntity))
             userOnceGroupService.cancelOnceGroup(userEntity, onceGroupEntity);
         else throw new GongBaekException(ResponseError.GROUP_CANCEL_NOT_FOUND);

--- a/src/main/java/com/ggang/be/api/group/validator/GroupValidator.java
+++ b/src/main/java/com/ggang/be/api/group/validator/GroupValidator.java
@@ -1,0 +1,23 @@
+package com.ggang.be.api.group.validator;
+
+import com.ggang.be.api.common.ResponseError;
+import com.ggang.be.api.exception.GongBaekException;
+import com.ggang.be.domain.constant.Status;
+import com.ggang.be.domain.group.everyGroup.EveryGroupEntity;
+import com.ggang.be.domain.group.onceGroup.OnceGroupEntity;
+import org.springframework.stereotype.Component;
+
+@Component
+public class GroupValidator {
+    public void isValidEveryGroup(EveryGroupEntity everyGroupEntity){
+        if(everyGroupEntity.getStatus() == Status.CLOSED){
+            throw new GongBaekException(ResponseError.GROUP_ALREADY_CLOSED);
+        }
+    }
+
+    public void isValidOnceGroup(OnceGroupEntity onceGroupEntity){
+        if(onceGroupEntity.getStatus() == Status.CLOSED){
+            throw new GongBaekException(ResponseError.GROUP_ALREADY_CLOSED);
+        }
+    }
+}

--- a/src/main/java/com/ggang/be/api/lectureTimeSlot/service/LectureTimeSlotService.java
+++ b/src/main/java/com/ggang/be/api/lectureTimeSlot/service/LectureTimeSlotService.java
@@ -16,4 +16,6 @@ public interface LectureTimeSlotService {
     boolean isActiveGroupsInLectureTimeSlot(UserEntity findUserEntity, GroupVo groupVo);
 
     List<LectureTimeSlotEntity> readUserTime(UserEntity userById);
+
+    void deleteUserTime(UserEntity userById);
 }

--- a/src/main/java/com/ggang/be/api/mapper/GroupResponseMapper.java
+++ b/src/main/java/com/ggang/be/api/mapper/GroupResponseMapper.java
@@ -11,6 +11,7 @@ public record GroupResponseMapper() {
     public static GroupResponse fromOnceGroup(OnceGroupDto dto) {
         return new GroupResponse(
             dto.groupId(),
+            dto.status(),
             GroupType.ONCE.toString(),
             dto.groupTitle(),
             dto.location(),
@@ -31,6 +32,7 @@ public record GroupResponseMapper() {
     public static GroupResponse fromEveryGroup(EveryGroupDto dto) {
         return new GroupResponse(
             dto.groupId(),
+            dto.status(),
             GroupType.WEEKLY.toString(),
             dto.title(),
             dto.location(),

--- a/src/main/java/com/ggang/be/api/user/controller/UserController.java
+++ b/src/main/java/com/ggang/be/api/user/controller/UserController.java
@@ -10,6 +10,7 @@ import com.ggang.be.api.facade.SignUpFacade;
 import com.ggang.be.api.facade.SignupRequestFacade;
 import com.ggang.be.api.user.NicknameValidator;
 import com.ggang.be.api.user.dto.*;
+import com.ggang.be.api.user.facade.UserFacade;
 import com.ggang.be.api.user.service.UserService;
 import com.ggang.be.global.jwt.JwtService;
 import com.ggang.be.global.jwt.TokenVo;
@@ -30,6 +31,7 @@ public class UserController {
     private final SignupRequestFacade signupRequestFacade;
     private final JwtService jwtService;
     private final MailFacade mailFacade;
+    private final UserFacade userFacade;
 
     private final static int INTRODUCTION_MIN_LENGTH = 0;
     private final static int INTRODUCTION_MAX_LENGTH = 100;
@@ -63,6 +65,20 @@ public class UserController {
         return ResponseBuilder.created(
                 signupFacade.signUp(platformId, request)
         );
+    }
+
+    @DeleteMapping("/withdraw")
+    public ResponseEntity<ApiResponse<Void>> deleteUser(
+            @RequestHeader("Authorization") String accessToken
+    ) {
+        log.info("withdraw authorization: {}", accessToken);
+
+        long userId = jwtService.parseTokenAndGetUserId(accessToken);
+        log.info("withdraw userId: {}", userId);
+
+        userFacade.deleteUser(userId);
+
+        return ResponseBuilder.ok(null);
     }
   
     @GetMapping("/user/home/profile")

--- a/src/main/java/com/ggang/be/api/user/facade/UserFacade.java
+++ b/src/main/java/com/ggang/be/api/user/facade/UserFacade.java
@@ -1,0 +1,74 @@
+package com.ggang.be.api.user.facade;
+
+import com.ggang.be.api.comment.service.CommentService;
+import com.ggang.be.api.gongbaekTimeSlot.service.GongbaekTimeSlotService;
+import com.ggang.be.api.group.everyGroup.service.EveryGroupService;
+import com.ggang.be.api.group.onceGroup.service.OnceGroupService;
+import com.ggang.be.api.lectureTimeSlot.service.LectureTimeSlotService;
+import com.ggang.be.api.user.service.UserService;
+import com.ggang.be.api.userEveryGroup.service.UserEveryGroupService;
+import com.ggang.be.api.userOnceGroup.service.UserOnceGroupService;
+import com.ggang.be.domain.user.UserEntity;
+import com.ggang.be.global.annotation.Facade;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.annotation.Transactional;
+
+@Facade
+@RequiredArgsConstructor
+@Slf4j
+public class UserFacade {
+
+    private final UserService userService;
+    private final CommentService commentService;
+    private final LectureTimeSlotService lectureTimeSlotService;
+    private final EveryGroupService everyGroupService;
+    private final OnceGroupService onceGroupService;
+    private final GongbaekTimeSlotService gongbaekTimeSlotService;
+    private final UserOnceGroupService userOnceGroupService;
+    private final UserEveryGroupService userEveryGroupService;
+
+    @Transactional
+    public void deleteUser(Long userId) {
+        UserEntity user = userService.getUserById(userId);
+        log.info("Fetched user: {}", user);
+
+        log.info("== Deleting lecture time slots");
+        lectureTimeSlotService.deleteUserTime(user);
+
+        log.info("== Canceling true false applied groups");
+        deleteUserGroupRelations(user);
+
+        log.info("== Removing comment author");
+        removeCommentAuthor(userId);
+
+        log.info("== Removing group host");
+        removeGroupHost(user);
+
+        log.info("== Removing gongbaek time slot user");
+        removeGongbaekTimeSlotUser(userId);
+
+        log.info("== Deleting user from repository");
+        userService.deleteUser(userId);
+    }
+
+    private void removeCommentAuthor(long userId) {
+        log.info("removeCommentAuthor called with userId={}", userId);
+        commentService.removeCommentAuthor(userId);
+    }
+
+    private void removeGroupHost(UserEntity user) {
+        log.info("Removing group host for user: {}", user.getId());
+        everyGroupService.deleteGroupHost(user);
+        onceGroupService.deleteGroupHost(user);
+    }
+
+    private void removeGongbaekTimeSlotUser(long userId) {
+        gongbaekTimeSlotService.removeGongbaekTimeSlotUser(userId);
+    }
+
+    private void deleteUserGroupRelations(UserEntity user) {
+        userEveryGroupService.deleteUserEveryGroup(user);
+        userOnceGroupService.deleteUserOnceGroup(user);
+    }
+}

--- a/src/main/java/com/ggang/be/api/user/facade/UserFacade.java
+++ b/src/main/java/com/ggang/be/api/user/facade/UserFacade.java
@@ -43,6 +43,7 @@ public class UserFacade {
         removeCommentAuthor(userId);
 
         log.info("== Removing group host");
+        modifyGroupStatus(user);
         removeGroupHost(user);
 
         log.info("== Removing gongbaek time slot user");
@@ -61,6 +62,11 @@ public class UserFacade {
         log.info("Removing group host for user: {}", user.getId());
         everyGroupService.deleteGroupHost(user);
         onceGroupService.deleteGroupHost(user);
+    }
+
+    private void modifyGroupStatus(UserEntity user) {
+        everyGroupService.modifyGroupStatus(user);
+        onceGroupService.modifyGroupStatus(user);
     }
 
     private void removeGongbaekTimeSlotUser(long userId) {

--- a/src/main/java/com/ggang/be/api/user/service/UserService.java
+++ b/src/main/java/com/ggang/be/api/user/service/UserService.java
@@ -30,4 +30,6 @@ public interface UserService {
     void checkDuplicatedEmail(String email);
 
     void removeRefreshToken(Long userId);
+
+    void deleteUser(Long userId);
 }

--- a/src/main/java/com/ggang/be/api/userEveryGroup/service/UserEveryGroupService.java
+++ b/src/main/java/com/ggang/be/api/userEveryGroup/service/UserEveryGroupService.java
@@ -23,4 +23,6 @@ public interface UserEveryGroupService {
     void cancelEveryGroup(UserEntity currentUser, EveryGroupEntity everyGroupEntity);
 
     void isUserInGroup(UserEntity findUserEntity, EveryGroupEntity findEveryGroupEntity);
+
+    void deleteUserEveryGroup(UserEntity user);
 }

--- a/src/main/java/com/ggang/be/api/userOnceGroup/service/UserOnceGroupService.java
+++ b/src/main/java/com/ggang/be/api/userOnceGroup/service/UserOnceGroupService.java
@@ -23,4 +23,6 @@ public interface UserOnceGroupService {
     void isValidCommentAccess(UserEntity userEntity, final long groupId);
 
     void isUserInGroup(UserEntity findUserEntity, OnceGroupEntity findOnceGroupEntity);
+
+    void deleteUserOnceGroup(UserEntity user);
 }

--- a/src/main/java/com/ggang/be/domain/comment/CommentEntity.java
+++ b/src/main/java/com/ggang/be/domain/comment/CommentEntity.java
@@ -32,4 +32,8 @@ public class CommentEntity extends BaseTimeEntity {
         this.isPublic = isPublic;
         this.body = body;
     }
+
+    public void removeAuthor() {
+        this.userEntity = null;
+    }
 }

--- a/src/main/java/com/ggang/be/domain/comment/application/CommentServiceImpl.java
+++ b/src/main/java/com/ggang/be/domain/comment/application/CommentServiceImpl.java
@@ -11,6 +11,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -40,5 +42,16 @@ public class CommentServiceImpl implements CommentService {
     public CommentEntity findById(final long commentId) {
         return commentRepository.findById(commentId)
                 .orElseThrow(() -> new GongBaekException(ResponseError.COMMENT_NOT_FOUND));
+    }
+
+    @Transactional
+    @Override
+    public void removeCommentAuthor(final long userId) {
+        List<CommentEntity> comments = commentRepository.findAllByUserEntity_Id(userId);
+
+        for (CommentEntity comment : comments) {
+            comment.removeAuthor();
+        }
+        commentRepository.saveAll(comments);
     }
 }

--- a/src/main/java/com/ggang/be/domain/comment/infra/CommentRepository.java
+++ b/src/main/java/com/ggang/be/domain/comment/infra/CommentRepository.java
@@ -3,6 +3,8 @@ package com.ggang.be.domain.comment.infra;
 import com.ggang.be.domain.comment.CommentEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface CommentRepository extends JpaRepository<CommentEntity, Long> {
+import java.util.List;
 
+public interface CommentRepository extends JpaRepository<CommentEntity, Long> {
+    List<CommentEntity> findAllByUserEntity_Id(Long userId);
 }

--- a/src/main/java/com/ggang/be/domain/common/SameSchoolValidator.java
+++ b/src/main/java/com/ggang/be/domain/common/SameSchoolValidator.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class SameSchoolValidator {
     public void isUserReadMySchoolEveryGroup(UserEntity userEntity, EveryGroupEntity everyGroupEntity) {
+        if(!isEveryGroupHostExist(everyGroupEntity)) return;
         String groupCreatorSchoolName = everyGroupEntity.getUserEntity().getSchool().getSchoolName();
         String userSchoolName = userEntity.getSchool().getSchoolName();
         if (!groupCreatorSchoolName.equals(userSchoolName))
@@ -17,10 +18,22 @@ public class SameSchoolValidator {
     }
 
     public void isUserReadMySchoolOnceGroup(UserEntity userEntity, OnceGroupEntity onceGroupEntity) {
+        if(!isOnceGroupHostExist(onceGroupEntity)) return;
         String groupCreatorSchoolName = onceGroupEntity.getUserEntity().getSchool().getSchoolName();
+        if(groupCreatorSchoolName == null) return;
+
         String userSchoolName = userEntity.getSchool().getSchoolName();
         if (!groupCreatorSchoolName.equals(userSchoolName))
             throw new GongBaekException(ResponseError.GROUP_ACCESS_SCHOOL_MISMATCH);
 
     }
+
+    private boolean isEveryGroupHostExist(EveryGroupEntity everyGroupEntity) {
+        return (everyGroupEntity.getUserEntity() != null);
+    }
+
+    private boolean isOnceGroupHostExist(OnceGroupEntity onceGroupEntity) {
+        return (onceGroupEntity.getUserEntity() != null);
+    }
+
 }

--- a/src/main/java/com/ggang/be/domain/group/everyGroup/EveryGroupEntity.java
+++ b/src/main/java/com/ggang/be/domain/group/everyGroup/EveryGroupEntity.java
@@ -91,6 +91,7 @@ public class EveryGroupEntity extends BaseTimeEntity {
     }
 
     public boolean isHost(UserEntity currentUser) {
+        if (this.userEntity == null) return false;
         return this.userEntity.getId().equals(currentUser.getId());
     }
 

--- a/src/main/java/com/ggang/be/domain/group/everyGroup/EveryGroupEntity.java
+++ b/src/main/java/com/ggang/be/domain/group/everyGroup/EveryGroupEntity.java
@@ -128,4 +128,8 @@ public class EveryGroupEntity extends BaseTimeEntity {
     public void removeHost() {
         this.userEntity = null;
     }
+
+    public void closeGroup() {
+        this.status = Status.CLOSED;
+    }
 }

--- a/src/main/java/com/ggang/be/domain/group/everyGroup/EveryGroupEntity.java
+++ b/src/main/java/com/ggang/be/domain/group/everyGroup/EveryGroupEntity.java
@@ -123,4 +123,8 @@ public class EveryGroupEntity extends BaseTimeEntity {
     public void updateStatus(Status status) {
         this.status = status;
     }
+
+    public void removeHost() {
+        this.userEntity = null;
+    }
 }

--- a/src/main/java/com/ggang/be/domain/group/everyGroup/application/EveryGroupServiceImpl.java
+++ b/src/main/java/com/ggang/be/domain/group/everyGroup/application/EveryGroupServiceImpl.java
@@ -72,6 +72,14 @@ public class EveryGroupServiceImpl implements EveryGroupService {
     }
 
     @Override
+    public void modifyGroupStatus(UserEntity currentUser) {
+        List<EveryGroupEntity> everyGroups = everyGroupRepository.findByUserEntity_Id(
+                currentUser.getId());
+        everyGroups.forEach(EveryGroupEntity::closeGroup);
+        everyGroupRepository.saveAll(everyGroups);
+    }
+
+    @Override
     public ReadEveryGroup getActiveEveryGroups(UserEntity currentUser, Category category) {
         List<EveryGroupEntity> everyGroupEntities;
         if(category == null) everyGroupEntities = everyGroupRepository.findAll();

--- a/src/main/java/com/ggang/be/domain/group/everyGroup/application/EveryGroupServiceImpl.java
+++ b/src/main/java/com/ggang/be/domain/group/everyGroup/application/EveryGroupServiceImpl.java
@@ -63,6 +63,14 @@ public class EveryGroupServiceImpl implements EveryGroupService {
     }
 
     @Override
+    public void deleteGroupHost(UserEntity currentUser) {
+        List<EveryGroupEntity> everyGroups = everyGroupRepository.findByUserEntity_Id(
+                currentUser.getId());
+        everyGroups.forEach(EveryGroupEntity::removeHost);
+        everyGroupRepository.saveAll(everyGroups);
+    }
+
+    @Override
     public ReadEveryGroup getActiveEveryGroups(UserEntity currentUser, Category category) {
         List<EveryGroupEntity> everyGroupEntities;
         if(category == null) everyGroupEntities = everyGroupRepository.findAll();

--- a/src/main/java/com/ggang/be/domain/group/everyGroup/application/EveryGroupServiceImpl.java
+++ b/src/main/java/com/ggang/be/domain/group/everyGroup/application/EveryGroupServiceImpl.java
@@ -50,6 +50,7 @@ public class EveryGroupServiceImpl implements EveryGroupService {
     @Override
     public long getEveryGroupRegisterUserId(final long groupId) {
         EveryGroupEntity entity = findIdOrThrow(groupId);
+        if(entity.getUserEntity() == null) throw new GongBaekException(ResponseError.USER_NOT_FOUND);
         return entity.getUserEntity().getId();
     }
 

--- a/src/main/java/com/ggang/be/domain/group/everyGroup/dto/EveryGroupDto.java
+++ b/src/main/java/com/ggang/be/domain/group/everyGroup/dto/EveryGroupDto.java
@@ -1,12 +1,14 @@
 package com.ggang.be.domain.group.everyGroup.dto;
 
 import com.ggang.be.domain.constant.Category;
+import com.ggang.be.domain.constant.Status;
 import com.ggang.be.domain.group.everyGroup.EveryGroupEntity;
 import com.ggang.be.domain.timslot.gongbaekTimeSlot.GongbaekTimeSlotEntity;
 import com.ggang.be.domain.user.UserEntity;
 
 public record EveryGroupDto(
         long groupId,
+        Status status,
         String title,
         String location,
         int currentPeopleCount,
@@ -21,6 +23,7 @@ public record EveryGroupDto(
     public static EveryGroupDto toDto(EveryGroupEntity entity, UserEntity currentUser) {
         return new EveryGroupDto(
                 entity.getId(),
+                entity.getStatus(),
                 entity.getTitle(),
                 entity.getLocation(),
                 entity.getCurrentPeopleCount(),

--- a/src/main/java/com/ggang/be/domain/group/everyGroup/dto/EveryGroupVo.java
+++ b/src/main/java/com/ggang/be/domain/group/everyGroup/dto/EveryGroupVo.java
@@ -11,14 +11,18 @@ import java.time.LocalDateTime;
 public record EveryGroupVo(long groupId, Status status, Category category, int coverImg, int profileImg,
                            String nickname, GroupType groupType,
                            String groupTitle, WeekDay weekDay, double startTime, double endTime, String location, LocalDateTime createdAt) {
+
     public static EveryGroupVo of(EveryGroupEntity everyGroupEntity) {
+        int profileImg = (everyGroupEntity.getUserEntity()) != null ? everyGroupEntity.getUserEntity().getProfileImg() : 0;
+        String nickname = (everyGroupEntity.getUserEntity()) != null ? everyGroupEntity.getUserEntity().getNickname() : null;
+
         return new EveryGroupVo(
                 everyGroupEntity.getId(),
                 everyGroupEntity.getStatus(),
                 everyGroupEntity.getCategory(),
                 everyGroupEntity.getCoverImg(),
-                everyGroupEntity.getUserEntity().getProfileImg(),
-                everyGroupEntity.getUserEntity().getNickname(),
+                profileImg,
+                nickname,
                 GroupType.WEEKLY,
                 everyGroupEntity.getTitle(),
                 everyGroupEntity.getGongbaekTimeSlotEntity().getWeekDay(),

--- a/src/main/java/com/ggang/be/domain/group/onceGroup/OnceGroupEntity.java
+++ b/src/main/java/com/ggang/be/domain/group/onceGroup/OnceGroupEntity.java
@@ -90,6 +90,7 @@ public class OnceGroupEntity extends BaseTimeEntity {
     }
 
     public boolean isHost(UserEntity currentUser) {
+        if (this.userEntity == null) return false;
         return this.userEntity.getId().equals(currentUser.getId());
     }
 
@@ -125,5 +126,9 @@ public class OnceGroupEntity extends BaseTimeEntity {
 
     public void removeHost() {
         this.userEntity = null;
+    }
+
+    public void closeGroup() {
+        this.status = Status.CLOSED;
     }
 }

--- a/src/main/java/com/ggang/be/domain/group/onceGroup/OnceGroupEntity.java
+++ b/src/main/java/com/ggang/be/domain/group/onceGroup/OnceGroupEntity.java
@@ -122,4 +122,8 @@ public class OnceGroupEntity extends BaseTimeEntity {
     public void updateStatus(Status status){
         this.status=status;
     }
+
+    public void removeHost() {
+        this.userEntity = null;
+    }
 }

--- a/src/main/java/com/ggang/be/domain/group/onceGroup/application/OnceGroupServiceImpl.java
+++ b/src/main/java/com/ggang/be/domain/group/onceGroup/application/OnceGroupServiceImpl.java
@@ -48,6 +48,7 @@ public class OnceGroupServiceImpl implements OnceGroupService {
     @Override
     public long getOnceGroupRegisterUserId(final long groupId) {
         OnceGroupEntity entity = findIdOrThrow(groupId);
+        if(entity.getUserEntity() == null) throw new GongBaekException(ResponseError.USER_NOT_FOUND);
         return entity.getUserEntity().getId();
     }
 

--- a/src/main/java/com/ggang/be/domain/group/onceGroup/application/OnceGroupServiceImpl.java
+++ b/src/main/java/com/ggang/be/domain/group/onceGroup/application/OnceGroupServiceImpl.java
@@ -68,6 +68,14 @@ public class OnceGroupServiceImpl implements OnceGroupService {
     }
 
     @Override
+    public void modifyGroupStatus(UserEntity currentUser) {
+        List<OnceGroupEntity> onceGroups = onceGroupRepository.findByUserEntity_Id(
+                currentUser.getId());
+        onceGroups.forEach(OnceGroupEntity::closeGroup);
+        onceGroupRepository.saveAll(onceGroups);
+    }
+
+    @Override
     public ReadOnceGroup getActiveOnceGroups(UserEntity currentUser, Category category) {
         List<OnceGroupEntity> onceGroupEntities;
         if(category == null) onceGroupEntities = onceGroupRepository.findAll();

--- a/src/main/java/com/ggang/be/domain/group/onceGroup/application/OnceGroupServiceImpl.java
+++ b/src/main/java/com/ggang/be/domain/group/onceGroup/application/OnceGroupServiceImpl.java
@@ -59,6 +59,14 @@ public class OnceGroupServiceImpl implements OnceGroupService {
     }
 
     @Override
+    public void deleteGroupHost(UserEntity currentUser) {
+        List<OnceGroupEntity> onceGroups = onceGroupRepository.findByUserEntity_Id(
+                currentUser.getId());
+        onceGroups.forEach(OnceGroupEntity::removeHost);
+        onceGroupRepository.saveAll(onceGroups);
+    }
+
+    @Override
     public ReadOnceGroup getActiveOnceGroups(UserEntity currentUser, Category category) {
         List<OnceGroupEntity> onceGroupEntities;
         if(category == null) onceGroupEntities = onceGroupRepository.findAll();

--- a/src/main/java/com/ggang/be/domain/group/onceGroup/dto/OnceGroupDto.java
+++ b/src/main/java/com/ggang/be/domain/group/onceGroup/dto/OnceGroupDto.java
@@ -1,6 +1,7 @@
 package com.ggang.be.domain.group.onceGroup.dto;
 
 import com.ggang.be.domain.constant.Category;
+import com.ggang.be.domain.constant.Status;
 import com.ggang.be.domain.constant.WeekDay;
 import com.ggang.be.domain.group.onceGroup.OnceGroupEntity;
 import com.ggang.be.domain.timslot.gongbaekTimeSlot.GongbaekTimeSlotEntity;
@@ -8,6 +9,7 @@ import com.ggang.be.domain.user.UserEntity;
 
 public record OnceGroupDto(
     long groupId,
+    Status status,
     String groupTitle,
     String location,
     int currentPeopleCount,
@@ -25,6 +27,7 @@ public record OnceGroupDto(
     public static OnceGroupDto toDto(OnceGroupEntity entity, UserEntity currentUser) {
         return new OnceGroupDto(
             entity.getId(),
+            entity.getStatus(),
             entity.getTitle(),
             entity.getLocation(),
             entity.getCurrentPeopleCount(),

--- a/src/main/java/com/ggang/be/domain/group/onceGroup/dto/OnceGroupVo.java
+++ b/src/main/java/com/ggang/be/domain/group/onceGroup/dto/OnceGroupVo.java
@@ -14,13 +14,16 @@ public record OnceGroupVo(long groupId, Status status, Category category, int co
                           String groupTitle, LocalDate dateTime, double startTime, double endTime, String location,
                           LocalDateTime createdAt, GongbaekTimeSlotEntity gongbaekTimeSlotEntity) {
     public static OnceGroupVo of(OnceGroupEntity onceGroupEntity) {
+        int profileImg = (onceGroupEntity.getUserEntity()) != null ? onceGroupEntity.getUserEntity().getProfileImg() : 0;
+        String nickname = (onceGroupEntity.getUserEntity()) != null ? onceGroupEntity.getUserEntity().getNickname() : null;
+
         return new OnceGroupVo(
                 onceGroupEntity.getId(),
                 onceGroupEntity.getStatus(),
                 onceGroupEntity.getCategory(),
                 onceGroupEntity.getCoverImg(),
-                onceGroupEntity.getUserEntity().getProfileImg(),
-                onceGroupEntity.getUserEntity().getNickname(),
+                profileImg,
+                nickname,
                 GroupType.ONCE,
                 onceGroupEntity.getTitle(),
                 onceGroupEntity.getGroupDate(),

--- a/src/main/java/com/ggang/be/domain/group/vo/GroupCommentVo.java
+++ b/src/main/java/com/ggang/be/domain/group/vo/GroupCommentVo.java
@@ -1,7 +1,6 @@
 package com.ggang.be.domain.group.vo;
 
 import com.ggang.be.domain.comment.CommentEntity;
-import com.ggang.be.domain.constant.GroupType;
 import com.ggang.be.domain.group.everyGroup.EveryGroupEntity;
 import com.ggang.be.domain.group.onceGroup.OnceGroupEntity;
 import com.ggang.be.domain.user.UserEntity;
@@ -9,34 +8,52 @@ import com.ggang.be.domain.user.UserEntity;
 import java.time.format.DateTimeFormatter;
 
 public record GroupCommentVo(
-        long commentId,boolean isWriter,
+        long commentId, boolean isWriter,
         boolean isGroupHost, String nickname, String body, String createdAt
 ) {
     private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd-HH-mm");
 
     public static GroupCommentVo ofEveryGroup(
-        UserEntity nowUserEntity,
-        EveryGroupEntity groupEntity, CommentEntity commentEntity) {
-        UserEntity commentUserEntity = commentEntity.getUserEntity();
-        Long creatorId = groupEntity.getUserEntity().getId();
-
-        return new GroupCommentVo(commentEntity.getId(),
-            commentUserEntity.getId().equals(nowUserEntity.getId()),
-            commentUserEntity.getId().equals(creatorId),
-            commentUserEntity.getNickname(), commentEntity.getBody(),
-            formatter.format(commentEntity.getCreatedAt()));
+            UserEntity nowUserEntity,
+            EveryGroupEntity groupEntity,
+            CommentEntity commentEntity
+    ) {
+        return from(nowUserEntity, groupEntity.getUserEntity(), commentEntity);
     }
 
     public static GroupCommentVo ofOnceGroup(
-        UserEntity nowUserEntity,
-        OnceGroupEntity groupEntity, CommentEntity commentEntity) {
-        UserEntity commentUserEntity = commentEntity.getUserEntity();
-        Long creatorId = groupEntity.getUserEntity().getId();
+            UserEntity nowUserEntity,
+            OnceGroupEntity groupEntity,
+            CommentEntity commentEntity
+    ) {
+        return from(nowUserEntity, groupEntity.getUserEntity(), commentEntity);
+    }
 
-        return new GroupCommentVo(commentEntity.getId(),
-            commentUserEntity.getId().equals(nowUserEntity.getId()),
-            commentUserEntity.getId().equals(creatorId),
-            commentUserEntity.getNickname(), commentEntity.getBody(),
-            formatter.format(commentEntity.getCreatedAt()));
+    private static GroupCommentVo from(
+            UserEntity nowUserEntity,
+            UserEntity groupCreator,
+            CommentEntity commentEntity
+    ) {
+        UserEntity commentUser = commentEntity.getUserEntity();
+
+        Long creatorId = groupCreator != null ? groupCreator.getId() : null;
+        boolean isMine = false;
+        boolean isHost = false;
+        String nickname = null;
+
+        if (commentUser != null) {
+            isMine = commentUser.getId().equals(nowUserEntity.getId());
+            isHost = creatorId != null && commentUser.getId().equals(creatorId);
+            nickname = commentUser.getNickname();
+        }
+
+        return new GroupCommentVo(
+                commentEntity.getId(),
+                isMine,
+                isHost,
+                nickname,
+                commentEntity.getBody(),
+                formatter.format(commentEntity.getCreatedAt())
+        );
     }
 }

--- a/src/main/java/com/ggang/be/domain/timslot/gongbaekTimeSlot/GongbaekTimeSlotEntity.java
+++ b/src/main/java/com/ggang/be/domain/timslot/gongbaekTimeSlot/GongbaekTimeSlotEntity.java
@@ -37,4 +37,8 @@ public class GongbaekTimeSlotEntity extends BaseTimeEntity {
         this.endTime = endTime;
         this.userEntity = userEntity;
     }
+
+    public void removeUserEntity() {
+        this.userEntity = null;
+    }
 }

--- a/src/main/java/com/ggang/be/domain/timslot/gongbaekTimeSlot/application/GongbaekTimeSlotServiceImpl.java
+++ b/src/main/java/com/ggang/be/domain/timslot/gongbaekTimeSlot/application/GongbaekTimeSlotServiceImpl.java
@@ -9,6 +9,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -28,5 +30,13 @@ public class GongbaekTimeSlotServiceImpl implements GongbaekTimeSlotService {
             .build();
 
         return gongbaekTimeSlotRepository.save(buildEntity);
+    }
+
+    @Transactional
+    @Override
+    public void removeGongbaekTimeSlotUser(long userId) {
+        List<GongbaekTimeSlotEntity> slots = gongbaekTimeSlotRepository.findByUserEntity_Id(userId);
+        slots.forEach(GongbaekTimeSlotEntity::removeUserEntity);
+        gongbaekTimeSlotRepository.saveAll(slots);
     }
 }

--- a/src/main/java/com/ggang/be/domain/timslot/gongbaekTimeSlot/infra/GongbaekTimeSlotRepository.java
+++ b/src/main/java/com/ggang/be/domain/timslot/gongbaekTimeSlot/infra/GongbaekTimeSlotRepository.java
@@ -3,5 +3,8 @@ package com.ggang.be.domain.timslot.gongbaekTimeSlot.infra;
 import com.ggang.be.domain.timslot.gongbaekTimeSlot.GongbaekTimeSlotEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface GongbaekTimeSlotRepository extends JpaRepository<GongbaekTimeSlotEntity, Long> {
+    List<GongbaekTimeSlotEntity> findByUserEntity_Id(Long id);
 }

--- a/src/main/java/com/ggang/be/domain/timslot/lectureTimeSlot/application/LectureTimeSlotServiceImpl.java
+++ b/src/main/java/com/ggang/be/domain/timslot/lectureTimeSlot/application/LectureTimeSlotServiceImpl.java
@@ -52,4 +52,10 @@ public class LectureTimeSlotServiceImpl implements LectureTimeSlotService {
             userById);
     }
 
+    @Override
+    public void deleteUserTime(UserEntity userById) {
+        List<LectureTimeSlotEntity> userLectureTimeSlots = readUserTime(userById);
+        lectureTimeSlotRepository.deleteAll(userLectureTimeSlots);
+    }
+
 }

--- a/src/main/java/com/ggang/be/domain/user/application/UserServiceImpl.java
+++ b/src/main/java/com/ggang/be/domain/user/application/UserServiceImpl.java
@@ -114,5 +114,13 @@ public class UserServiceImpl implements UserService {
 
         user.updateRefreshToken(null);
     }
+
+    @Transactional
+    @Override
+    public void deleteUser(Long userId) {
+        log.info("delete User start ======");
+        userRepository.deleteById(userId);
+        log.info("delete User clear ======");
+    }
 }
 

--- a/src/main/java/com/ggang/be/domain/userEveryGroup/application/UserEveryGroupServiceImpl.java
+++ b/src/main/java/com/ggang/be/domain/userEveryGroup/application/UserEveryGroupServiceImpl.java
@@ -21,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 
@@ -77,7 +78,9 @@ public class UserEveryGroupServiceImpl implements UserEveryGroupService {
         List<UserEveryGroupEntity> userEveryGroupEntities = getMyEveryGroup(currentUser);
 
         List<EveryGroupEntity> filteredGroups = getGroupsByStatus(userEveryGroupEntities, status).stream()
-                .filter(group -> !group.getUserEntity().getId().equals(currentUser.getId()))
+                .filter(group -> Optional.ofNullable(group.getUserEntity())
+                        .map(host -> !host.getId().equals(currentUser.getId()))
+                        .orElse(true))
                 .toList();
 
         return ReadEveryGroup.of(groupVoMaker.makeEveryGroup(filteredGroups));

--- a/src/main/java/com/ggang/be/domain/userEveryGroup/application/UserEveryGroupServiceImpl.java
+++ b/src/main/java/com/ggang/be/domain/userEveryGroup/application/UserEveryGroupServiceImpl.java
@@ -103,6 +103,11 @@ public class UserEveryGroupServiceImpl implements UserEveryGroupService {
 
     }
 
+    @Override
+    public void deleteUserEveryGroup(UserEntity user){
+        userEveryGroupRepository.deleteAll(user.getUserEveryGroupEntities());
+    }
+
     private EveryGroupEntity getNearestGroup(List<EveryGroupEntity> groups) {
         return groups.stream()
                 .min(Comparator.comparing(group -> WeekDay.getNextMeetingDate(group.getGongbaekTimeSlotEntity().getWeekDay())))

--- a/src/main/java/com/ggang/be/domain/userOnceGroup/application/UserOnceGroupServiceImpl.java
+++ b/src/main/java/com/ggang/be/domain/userOnceGroup/application/UserOnceGroupServiceImpl.java
@@ -103,6 +103,11 @@ public class UserOnceGroupServiceImpl implements UserOnceGroupService {
         }
     }
 
+    @Override
+    public void deleteUserOnceGroup(UserEntity user){
+        userOnceGroupRepository.deleteAll(user.getUserOnceGroupEntites());
+    }
+
     private OnceGroupEntity getNearestGroup(List<OnceGroupEntity> groups) {
         return groups.stream()
             .min(Comparator.comparing(OnceGroupEntity::getGroupDate))

--- a/src/main/java/com/ggang/be/domain/userOnceGroup/application/UserOnceGroupServiceImpl.java
+++ b/src/main/java/com/ggang/be/domain/userOnceGroup/application/UserOnceGroupServiceImpl.java
@@ -19,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -44,8 +45,10 @@ public class UserOnceGroupServiceImpl implements UserOnceGroupService {
 
         List<OnceGroupEntity> filteredGroups = getGroupsByStatus(userOnceGroupEntities,
             status).stream()
-            .filter(group -> !group.getUserEntity().getId().equals(currentUser.getId()))
-            .toList();
+                .filter(group -> Optional.ofNullable(group.getUserEntity())
+                        .map(host -> !host.getId().equals(currentUser.getId()))
+                        .orElse(true))
+                .toList();
 
         return ReadOnceGroup.of(groupVoMaker.makeOnceGroup(filteredGroups));
     }


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### #️⃣관련 이슈
- #21 

### 🎋 작업중인 브랜치
- feat/#21

### 💡 작업내용
- 유저 탈퇴 시 NPE(NullPointerException) 발생 문제를 해결했습니다.
- 탈퇴한 유저가 생성한 모임의 상태를 CLOSED로 일괄 변경하는 기능을 추가했습니다.
- 탈퇴한 유저의 정보를 조회할 경우 `404 에러`를 반환했습니다.
- 탈퇴 후에도 해당 유저가 작성한 게시글 및 댓글이 정상적으로 조회될 수 있도록 처리했습니다.
- 탈퇴한 유저의 게시글이나 댓글의 경우 user 의 정보를 null 로 처리했습니다.
```json
{
    "success": true,
    "code": 2000,
    "message": "성공하였습니다.",
    "data": {
        "commentCount": 2,
        "groupId": 5,
        "groupType": "WEEKLY",
        "groupStatus": "RECRUITING",
        "comments": [
            {
                "commentId": 8,
                "isWriter": false,
                "isGroupHost": false,
                "nickname": null,
                "body": "모임은 이번주부터 하는 걸까요?",
                "createdAt": "2025-03-28-16-42"
            },
            {
                "commentId": 9,
                "isWriter": false,
                "isGroupHost": false,
                "nickname": null,
                "body": "모임은 이번주부터 하는 걸까요?",
                "createdAt": "2025-03-28-20-00"
            }
        ]
    }
}
```

### 🔑 주요 변경사항
- UserFacade 내 deleteUser 로직에 modifyGroupStatus 추가
- EveryGroupServiceImpl, OnceGroupServiceImpl에 modifyGroupStatus 메서드 구현 
    → 유저가 생성한 모임 상태를 `CLOSED`로 변경
- 댓글 및 모임 조회 시 작성자(UserEntity)가 null일 수 있는 경우를 모두 null safe 하게 변경
- GroupCommentVo, isHost(), toDto() 등 주요 메서드에서 NPE 방지 조건 추가
- 유저 탈퇴 시 JPA 관계 정리 및 soft-delete가 아닌 작성자 정보만 null 처리하는 물리적 삭제 로직 정비


### 🏞 스크린샷
<img width="500" alt="image" src="https://github.com/user-attachments/assets/ab8119b0-2e2d-47ae-a422-a9272dac89da" />


closes #21 
