### PR TITLE
[hotfix] #45 JWT 토큰 만료 분기처리

### DIFF
--- a/src/main/java/com/ggang/be/global/jwt/JwtService.java
+++ b/src/main/java/com/ggang/be/global/jwt/JwtService.java
@@ -7,6 +7,7 @@ import com.ggang.be.api.exception.GongBaekException;
 import com.ggang.be.api.user.service.UserService;
 import com.ggang.be.domain.user.UserEntity;
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
@@ -109,10 +110,14 @@ public class JwtService {
             }
             return userId;
         } catch (JwtException | NumberFormatException e) {
-            log.error("JWT parsing error : {}", e.getMessage());
+            if (e instanceof ExpiredJwtException) {
+                log.error("JWT expired: {}", e.getMessage());
+                throw new GongBaekException(ResponseError.EXPIRED_TOKEN);
+            }
+
+            log.error("Invalid JWT: {}", e.getMessage());
             throw new GongBaekException(ResponseError.INVALID_TOKEN);
         }
-
     }
 
     private Long parseTokenAndGetUserId(SecretKey secretKey, String token) {


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### #️⃣관련 이슈
- #45 

### 🎋 작업중인 브랜치
- fix/#45

### 💡 작업내용
- 기존에는 JWT 관련 예외를 모두 INVALID_TOKEN으로 처리하고 있었으나, 토큰이 만료된 경우 사용자에게 별도의 안내 메시지를 제공하기 위해 예외 분기 처리를 진행했습니다.

### 🔑 주요 변경사항
- ExpiredJwtException 과 그 외 JWT 예외를 구분하여 ResponseError.EXPIRED_TOKEN 과 ResponseError.INVALID_TOKEN 으로 분기 처리

### 🏞 스크린샷
N/A

closes #45 
