### PR TITLE
[fix] #53 장소 입력 시 특수문자 사용 가능하도록 변경

### DIFF
--- a/src/main/java/com/ggang/be/domain/group/LocationValidator.java
+++ b/src/main/java/com/ggang/be/domain/group/LocationValidator.java
@@ -12,7 +12,7 @@ import java.util.regex.Pattern;
 @Slf4j
 public class LocationValidator {
 
-    private static final Pattern pattern = Pattern.compile("^[가-힣a-zA-Z\s0-9]+$");
+    private static final Pattern pattern = Pattern.compile("^[가-힣a-zA-Z0-9 !@#$%^&*()\\-_=+{}\\[\\]:;\"'<>,.?/~`|\\\\]+$");
 
     public void isLocationValid(final String value){
         log.info("now Location value is : {}", value);

--- a/src/test/java/com/ggang/be/domain/group/LocationValidatorTest.java
+++ b/src/test/java/com/ggang/be/domain/group/LocationValidatorTest.java
@@ -1,0 +1,67 @@
+package com.ggang.be.domain.group;
+
+import com.ggang.be.api.exception.GongBaekException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+class LocationValidatorTest {
+
+    private LocationValidator locationValidator;
+
+    @BeforeEach
+    void setUp() {
+        locationValidator = new LocationValidator();
+    }
+
+    @Nested
+    @DisplayName("장소 검증 성공 케이스")
+    class SuccessCases {
+
+        @Test
+        @DisplayName("한글, 영어, 숫자, 공백, 특수문자가 포함된 정상 입력")
+        void validLocation() {
+            assertDoesNotThrow(() -> locationValidator.isLocationValid("학교 운동장-2번출구!"));
+            assertDoesNotThrow(() -> locationValidator.isLocationValid("Gongbaek  ~"));
+            assertDoesNotThrow(() -> locationValidator.isLocationValid("런닝 클럽@강남"));
+        }
+    }
+
+    @Nested
+    @DisplayName("장소 검증 실패 케이스")
+    class FailCases {
+
+        @Test
+        @DisplayName("엔터(줄바꿈)가 포함된 입력")
+        void locationWithNewLine() {
+            assertThatThrownBy(() -> locationValidator.isLocationValid("학교\n운동장"))
+                    .isInstanceOf(GongBaekException.class);
+        }
+
+        @Test
+        @DisplayName("이모지가 포함된 입력")
+        void locationWithEmoji() {
+            assertThatThrownBy(() -> locationValidator.isLocationValid("강남역✨출구"))
+                    .isInstanceOf(GongBaekException.class);
+        }
+
+        @Test
+        @DisplayName("길이가 2자 미만인 경우")
+        void tooShortLocation() {
+            assertThatThrownBy(() -> locationValidator.isLocationValid("A"))
+                    .isInstanceOf(GongBaekException.class);
+        }
+
+        @Test
+        @DisplayName("길이가 20자 초과인 경우")
+        void tooLongLocation() {
+            String tooLong = "학교운동장강남역출구학교운동장강남역출구!!";
+            assertThatThrownBy(() -> locationValidator.isLocationValid(tooLong))
+                    .isInstanceOf(GongBaekException.class);
+        }
+    }
+}


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### #️⃣관련 이슈
- #53 

### 🎋 작업중인 브랜치
- fix/#53

### 💡 작업내용
- 그룹 장소 입력 시 특수문자 사용을 허용하는 기획 변경을 반영했습니다.
- 기존에는 한글/영어/숫자/공백만 허용했지만, 이번 변경으로 기본 특수문자(!@#$%...) 입력도 가능해졌습니다.
- 줄바꿈(엔터)과 이모지(emoji)는 여전히 허용하지 않습니다.

### 🔑 주요 변경사항
1. LocationValidator 클래스 내 정규식 수정
```
- \s 대신 ' ' (스페이스)만 허용하도록 변경하여 줄바꿈 차단
- 한글, 영어, 숫자, 기본 특수문자 허용
```

2. LocationValidatorTest 테스트 코드 추가
```
- 정상 케이스(한글/영어/숫자/특수문자 포함) 검증
- 실패 케이스(줄바꿈 포함, 이모지 포함, 길이 초과 등) 검증
```

### 🏞 스크린샷
<img width="1024" alt="image" src="https://github.com/user-attachments/assets/9c7eda31-1118-4c63-baa3-5c1ae3f6f3e0" />

closes #53 
