### PR TITLE
[fix] #56 모임의 커버 이미지 인덱스 범위 수정

### DIFF
--- a/src/main/java/com/ggang/be/api/facade/GroupRequestFacade.java
+++ b/src/main/java/com/ggang/be/api/facade/GroupRequestFacade.java
@@ -47,7 +47,7 @@ public class GroupRequestFacade {
     }
 
     private void isValidCoverImg(RegisterGongbaekRequest dto) {
-        if(dto.coverImg()<1 || dto.coverImg()>6) {
+        if(dto.coverImg()<0 || dto.coverImg()>5) {
             log.error("그룹 coverImg 검증에 실패하였습니다.");
             throw new GongBaekException(ResponseError.BAD_REQUEST);
         }


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### #️⃣관련 이슈
- #56 

### 🎋 작업중인 브랜치
- fix/#56

### 💡 작업내용
- 모임의 커버 이미지 인덱스 범위 수정

### 🔑 주요 변경사항
- 기존의 1 ~ 6이 었던 인덱스를, 0 ~ 5로 변경했습니다.
 
### 🏞 스크린샷
<img width="624" alt="image" src="https://github.com/user-attachments/assets/96e9d76c-eb7a-43e2-9e41-6a09bc3a1e84" />
<img width="655" alt="image" src="https://github.com/user-attachments/assets/4e3bcc3c-197d-47ea-82df-370037e33f42" />

closes #56 
