### PR TITLE
[fix] #76 Caffeine 캐시 만료 시 실제 entry가 제거되지 않는 문제 해결

### DIFF
--- a/src/main/java/com/ggang/be/api/email/service/AuthCodeCacheService.java
+++ b/src/main/java/com/ggang/be/api/email/service/AuthCodeCacheService.java
@@ -2,6 +2,7 @@ package com.ggang.be.api.email.service;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.Scheduler;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -27,6 +28,8 @@ public class AuthCodeCacheService {
         this.authCodeCache = Caffeine.newBuilder()
                 .expireAfterWrite(Duration.ofMillis(expirationMillis))
                 .maximumSize(10000)
+                .scheduler(Scheduler.systemScheduler())
+                .recordStats()
                 .build();
     }
 

--- a/src/test/java/com/ggang/be/api/email/service/AuthCodeCacheServiceTest.java
+++ b/src/test/java/com/ggang/be/api/email/service/AuthCodeCacheServiceTest.java
@@ -1,0 +1,89 @@
+package com.ggang.be.api.email.service;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.Scheduler;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AuthCodeCacheServiceTest {
+
+    @Test
+    void scheduler없으면_캐시가_자동_만료되지_않을_수_있다() throws InterruptedException {
+        Cache<String, String> cache = Caffeine.newBuilder()
+                .expireAfterWrite(Duration.ofSeconds(5))
+                .maximumSize(100)
+                .recordStats()
+                .build();
+
+        cache.put("gongbaek@school.com", "123456");
+        System.out.println("저장 직후 estimatedSize: " + cache.estimatedSize());
+
+        Thread.sleep(6000);
+
+        String result = cache.getIfPresent("gongbaek@school.com");
+        System.out.println("6초 후 조회 결과 (scheduler 없음): " + result);
+        System.out.println("evictionCount: " + cache.stats().evictionCount());
+        System.out.println("estimatedSize: " + cache.estimatedSize());
+
+        assertThat(result).isNull();
+    }
+
+    @Test
+    void scheduler있으면_시간이_지나면_자동으로_캐시가_지워진다() throws InterruptedException {
+        Cache<String, String> cache = Caffeine.newBuilder()
+                .expireAfterWrite(Duration.ofSeconds(5))
+                .maximumSize(100)
+                .scheduler(Scheduler.systemScheduler()) // scheduler 적용
+                .recordStats()
+                .build();
+
+        cache.put("gongbaek@school.com", "123456");
+        System.out.println("저장 직후 estimatedSize: " + cache.estimatedSize());
+
+        Thread.sleep(6000);
+
+        String result = cache.getIfPresent("gongbaek@school.com");
+        System.out.println("6초 후 조회 결과 (scheduler 없음): " + result);
+        System.out.println("evictionCount: " + cache.stats().evictionCount());
+        System.out.println("estimatedSize: " + cache.estimatedSize());
+
+        assertThat(result).isNull();
+    }
+
+    @Test
+    void scheduler적용_전후_메모리_사용량_차이_확인() throws InterruptedException {
+        Runtime runtime = Runtime.getRuntime();
+
+        // heap 사용량 측정 함수
+        Runnable printMemory = () -> {
+            long used = runtime.totalMemory() - runtime.freeMemory();
+            System.out.println("Used memory: " + used / 1024 / 1024 + "MB");
+        };
+
+        Cache<String, String> cache = Caffeine.newBuilder()
+                .expireAfterWrite(Duration.ofSeconds(5))
+                .maximumSize(100_000)
+                .scheduler(Scheduler.systemScheduler())
+                .build();
+
+        for (int i = 0; i < 100_000; i++) {
+            cache.put("gongbaek" + i + "@school.com", "code" + i);
+        }
+
+        System.out.println("1. 대량 저장 후 메모리");
+        printMemory.run();
+
+        Thread.sleep(6000);
+        System.gc();
+        Thread.sleep(1000); // GC 여유
+
+        System.out.println("2. 만료 및 GC 이후 메모리");
+        printMemory.run();
+
+        System.out.println("estimatedSize: " + cache.estimatedSize());
+    }
+}


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### #️⃣관련 이슈
- #76 

### 🎋 작업중인 브랜치
- fix/#76

### 💡 작업내용
- Caffeine의 expireAfterWrite 옵션만으로는 entry가 만료 후에도 실제로 제거되지 않는 문제 발견
- 명확한 만료 및 메모리 관리 개선을 위해 .scheduler(Scheduler.systemScheduler()) 설정 추가
- 캐시 동작 검증을 위한 테스트 코드(AuthCodeCacheServiceTest)를 작성하여 scheduler 적용 전후의 동작 차이를 수치적으로 확인

### 🔑 주요 변경사항
1. `AuthCodeCacheService`
- `.scheduler(Scheduler.systemScheduler())` 적용
- `.recordStats()` 추가

2. `AuthCodeCacheServiceTest`
- `scheduler` 적용 전후 캐시 만료 테스트
- `evictionCount`, `estimatedSize`,` heap memory` 비교 테스트 포함


### 🏞 스크린샷
1. 스케줄러 없는 경우
<img width="407" alt="image" src="https://github.com/user-attachments/assets/2f065d06-15b5-4f79-b1f6-d73bc9e490ab" />

2. 스케줄러 있는 경우
<img width="391" alt="image" src="https://github.com/user-attachments/assets/cde9d5d9-53b0-404d-bb56-220cec05ff41" />

closes #76 
