### PR TITLE
[fix] #84 Block 엔티티 연관관계 누락으로 인한 회원탈퇴 실패 수정

### DIFF
--- a/src/main/java/com/ggang/be/api/user/dto/SignUpRequest.java
+++ b/src/main/java/com/ggang/be/api/user/dto/SignUpRequest.java
@@ -10,8 +10,8 @@ import com.ggang.be.domain.user.dto.SaveUserSignUp;
 import java.util.List;
 
 public record SignUpRequest(Platform platform,
-        String email,
-        Integer profileImg,
+                            String email,
+                            Integer profileImg,
                             String nickname,
                             Mbti mbti,
                             String schoolName,
@@ -20,7 +20,7 @@ public record SignUpRequest(Platform platform,
                             String introduction,
                             Gender sex,
                             List<TimeTableVo> timeTable
-                            ) {
+) {
 
     public static SaveUserSignUp toSaveUserSignUp(SignUpRequest request, String platformUserId, SchoolEntity school) {
         return new SaveUserSignUp(

--- a/src/main/java/com/ggang/be/api/user/facade/UserFacade.java
+++ b/src/main/java/com/ggang/be/api/user/facade/UserFacade.java
@@ -8,6 +8,7 @@ import com.ggang.be.api.lectureTimeSlot.service.LectureTimeSlotService;
 import com.ggang.be.api.user.service.UserService;
 import com.ggang.be.api.userEveryGroup.service.UserEveryGroupService;
 import com.ggang.be.api.userOnceGroup.service.UserOnceGroupService;
+import com.ggang.be.domain.block.application.BlockServiceImpl;
 import com.ggang.be.domain.user.UserEntity;
 import com.ggang.be.global.annotation.Facade;
 import lombok.RequiredArgsConstructor;
@@ -27,6 +28,7 @@ public class UserFacade {
     private final GongbaekTimeSlotService gongbaekTimeSlotService;
     private final UserOnceGroupService userOnceGroupService;
     private final UserEveryGroupService userEveryGroupService;
+    private final BlockServiceImpl blockService;
 
     @Transactional
     public void deleteUser(Long userId) {
@@ -49,8 +51,15 @@ public class UserFacade {
         log.info("== Removing gongbaek time slot user");
         removeGongbaekTimeSlotUser(userId);
 
+        log.info("== Removing blocks associated with user");
+        deleteBlocksByUser(user);
+
         log.info("== Deleting user from repository");
         userService.deleteUser(userId);
+    }
+
+    private void deleteBlocksByUser(UserEntity user) {
+        blockService.deleteBlocksByUser(user);
     }
 
     private void removeCommentAuthor(long userId) {

--- a/src/main/java/com/ggang/be/domain/block/application/BlockServiceImpl.java
+++ b/src/main/java/com/ggang/be/domain/block/application/BlockServiceImpl.java
@@ -1,51 +1,53 @@
 package com.ggang.be.domain.block.application;
 
-import java.util.List;
-
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import com.ggang.be.api.common.ResponseError;
 import com.ggang.be.api.exception.GongBaekException;
 import com.ggang.be.domain.block.BlockEntity;
 import com.ggang.be.domain.block.infra.BlockRepository;
 import com.ggang.be.domain.report.ReportEntity;
 import com.ggang.be.domain.user.UserEntity;
-
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class BlockServiceImpl {
 
-	private final BlockRepository blockRepository;
+    private final BlockRepository blockRepository;
 
-	@Transactional
-	public void blockUser(ReportEntity reportEntity, UserEntity userEntity) {
-		blockRepository.save(buildBlockEntity(reportEntity, userEntity));
-	}
+    @Transactional
+    public void blockUser(ReportEntity reportEntity, UserEntity userEntity) {
+        blockRepository.save(buildBlockEntity(reportEntity, userEntity));
+    }
 
+    public List<String> findUserBlocks(long userId) {
+        return blockRepository.findUserId(userId)
+                .stream()
+                .map(UserEntity::getNickname)
+                .toList();
+    }
 
-	public List<String> findUserBlocks(long userId){
-		return blockRepository.findUserId(userId)
-			.stream()
-			.map(UserEntity::getNickname)
-			.toList();
-	}
+    private BlockEntity buildBlockEntity(ReportEntity reportEntity, UserEntity userEntity) {
+        return BlockEntity.builder()
+                .report(reportEntity)
+                .user(userEntity)
+                .build();
+    }
 
-	private BlockEntity buildBlockEntity(ReportEntity reportEntity, UserEntity userEntity) {
-		return BlockEntity.builder()
-			.report(reportEntity)
-			.user(userEntity)
-			.build();
-	}
+    public List<String> findByReports(List<ReportEntity> reports) {
+        return reports.stream()
+                .map(reportEntity -> blockRepository.findByReport(reportEntity).orElseThrow(() -> new GongBaekException(
+                        ResponseError.NOT_FOUND)))
+                .map(blockEntity -> blockEntity.getUser().getNickname())
+                .toList();
+    }
 
-	public List<String> findByReports(List<ReportEntity> reports) {
-		return reports.stream()
-			.map(reportEntity -> blockRepository.findByReport(reportEntity).orElseThrow(() -> new GongBaekException(
-				ResponseError.NOT_FOUND)))
-			.map(blockEntity -> blockEntity.getUser().getNickname())
-			.toList();
-	}
+    @Transactional
+    public void deleteBlocksByUser(UserEntity user) {
+        blockRepository.deleteAllByUser(user);
+    }
 }

--- a/src/main/java/com/ggang/be/domain/block/infra/BlockRepository.java
+++ b/src/main/java/com/ggang/be/domain/block/infra/BlockRepository.java
@@ -17,4 +17,6 @@ public interface BlockRepository extends JpaRepository<BlockEntity, Long> {
 	List<UserEntity> findUserId(@Param("userId") Long userId);
 
 	Optional<BlockEntity> findByReport(ReportEntity report);
+
+	void deleteAllByUser(UserEntity user);
 }


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### #️⃣관련 이슈
- ex) #이슈번호, #이슈번호

### 🎋 작업중인 브랜치
- fix/#84

### 💡 작업내용
신고 기능 추가 시 생성한 BlockEntity의 연관관계 처리가 누락되어, 회원 탈퇴 시 외래 키 제약조건 위반으로 탈퇴가 실패하는 문제가 발생했습니다. 이 문제를 해결하기 위해 회원 탈퇴 로직에서 BlockEntity를 삭제하는 기능을 추가했습니다.

🔑

### 🔑 주요 변경사항
- UserFacade의 deleteUser() 메서드에서 회원 탈퇴 시 BlockEntity 삭제 로직 추가
- BlockServiceImpl에 사용자 기준 BlockEntity 삭제 메서드 deleteBlocksByUser(UserEntity user) 추가
- BlockRepository에 사용자 기준 BlockEntity 삭제를 위한 deleteAllByUser(UserEntity user) 메서드 추가

### 🏞 스크린샷
<img width="634" height="245" alt="image" src="https://github.com/user-attachments/assets/bdbf389b-a2e1-4006-aa97-f1f7e1ed99ab" />

closes #84
