### PR TITLE
[feat] #90 댓글 신고 시 해당 사용자의 모임을 취소하고 보이지 않도록 처리

### DIFF
--- a/src/main/java/com/ggang/be/api/facade/ReportFacade.java
+++ b/src/main/java/com/ggang/be/api/facade/ReportFacade.java
@@ -23,16 +23,16 @@ public class ReportFacade {
     private final GroupFacade groupFacade;
     private final CommentService commentService;
 
-    public ResponseSuccess reportComment(long userId, long commentId) {
-
+    public ResponseSuccess reportComment(long reporterId, long commentId) {
         CommentEntity commentEntity = commentService.findById(commentId);
+        UserEntity reportedUser = commentEntity.getUserEntity();
 
-        UserEntity userEntity = commentEntity.getUserEntity();
-        long reportedId = userEntity.getId();
+        ReportEntity reportEntity = reportService.reportComment(
+                commentId, reporterId, reportedUser.getId());
 
-        ReportEntity reportEntity = reportService.reportComment(commentId, userId, reportedId);
+        blockService.blockUser(reportEntity, reportedUser);
 
-        blockService.blockUser(reportEntity, userEntity);
+        groupFacade.cancelApplicationToReportedUserGroups(reporterId, reportedUser.getId());
 
         return ResponseSuccess.CREATED;
     }

--- a/src/main/java/com/ggang/be/api/group/everyGroup/service/EveryGroupService.java
+++ b/src/main/java/com/ggang/be/api/group/everyGroup/service/EveryGroupService.java
@@ -11,6 +11,8 @@ import com.ggang.be.domain.group.vo.ReadCommentGroup;
 import com.ggang.be.domain.timslot.gongbaekTimeSlot.GongbaekTimeSlotEntity;
 import com.ggang.be.domain.user.UserEntity;
 
+import java.util.List;
+
 public interface EveryGroupService {
     EveryGroupDto getEveryGroupDetail(final long groupId, UserEntity userEntity);
 
@@ -42,4 +44,6 @@ public interface EveryGroupService {
     void updateStatus();
 
     boolean isSameSchoolEveryGroup(UserEntity currentUser, EveryGroupVo groupVo);
+
+    List<EveryGroupEntity> findByUserId(Long userId);
 }

--- a/src/main/java/com/ggang/be/api/group/everyGroup/strategy/CancelEveryGroupStrategy.java
+++ b/src/main/java/com/ggang/be/api/group/everyGroup/strategy/CancelEveryGroupStrategy.java
@@ -33,4 +33,10 @@ public class CancelEveryGroupStrategy implements CancelGroupStrategy {
             userEveryGroupService.cancelEveryGroup(userEntity, everyGroupEntity);
         else throw new GongBaekException(ResponseError.GROUP_CANCEL_NOT_FOUND);
     }
+
+    @Override
+    public boolean hasApplied(UserEntity userEntity, GroupRequest request) {
+        EveryGroupEntity group = everyGroupService.findEveryGroupEntityByGroupId(request.groupId());
+        return userEveryGroupService.hasApplied(userEntity, group);
+    }
 }

--- a/src/main/java/com/ggang/be/api/group/everyGroup/strategy/FindEveryGroupsByUserStrategy.java
+++ b/src/main/java/com/ggang/be/api/group/everyGroup/strategy/FindEveryGroupsByUserStrategy.java
@@ -1,0 +1,29 @@
+package com.ggang.be.api.group.everyGroup.strategy;
+
+import com.ggang.be.api.group.dto.GroupRequest;
+import com.ggang.be.api.group.everyGroup.service.EveryGroupService;
+import com.ggang.be.api.group.registry.FindGroupsByUserStrategy;
+import com.ggang.be.domain.constant.GroupType;
+import com.ggang.be.global.annotation.Strategy;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@Strategy
+@RequiredArgsConstructor
+public class FindEveryGroupsByUserStrategy implements FindGroupsByUserStrategy {
+
+    private final EveryGroupService everyGroupService;
+
+    @Override
+    public GroupType getGroupType() {
+        return GroupType.WEEKLY;
+    }
+
+    @Override
+    public List<GroupRequest> toGroupRequests(Long userId) {
+        return everyGroupService.findByUserId(userId).stream()
+                .map(group -> new GroupRequest(group.getId(), GroupType.WEEKLY))
+                .toList();
+    }
+}

--- a/src/main/java/com/ggang/be/api/group/onceGroup/service/OnceGroupService.java
+++ b/src/main/java/com/ggang/be/api/group/onceGroup/service/OnceGroupService.java
@@ -11,6 +11,8 @@ import com.ggang.be.domain.group.vo.ReadCommentGroup;
 import com.ggang.be.domain.timslot.gongbaekTimeSlot.GongbaekTimeSlotEntity;
 import com.ggang.be.domain.user.UserEntity;
 
+import java.util.List;
+
 public interface OnceGroupService {
     OnceGroupDto getOnceGroupDetail(final long groupId, UserEntity user);
 
@@ -25,7 +27,7 @@ public interface OnceGroupService {
     ReadCommentGroup readCommentInGroup(UserEntity userEntity, boolean isPublic, final long groupId);
 
     OnceGroupEntity registerOnceGroup(RegisterGroupServiceRequest serviceRequest,
-                           GongbaekTimeSlotEntity gongbaekTimeSlotEntity);
+                                      GongbaekTimeSlotEntity gongbaekTimeSlotEntity);
 
     void deleteOnceGroup(UserEntity currentUser, OnceGroupEntity onceGroupEntity);
 
@@ -42,4 +44,6 @@ public interface OnceGroupService {
     void updateStatus();
 
     boolean isSameSchoolOnceGroup(UserEntity currentUser, OnceGroupVo groupVo);
+
+    List<OnceGroupEntity> findByUserId(Long userId);
 }

--- a/src/main/java/com/ggang/be/api/group/onceGroup/strategy/CancelOnceGroupStrategy.java
+++ b/src/main/java/com/ggang/be/api/group/onceGroup/strategy/CancelOnceGroupStrategy.java
@@ -33,4 +33,10 @@ public class CancelOnceGroupStrategy implements CancelGroupStrategy {
             userOnceGroupService.cancelOnceGroup(userEntity, onceGroupEntity);
         else throw new GongBaekException(ResponseError.GROUP_CANCEL_NOT_FOUND);
     }
+
+    @Override
+    public boolean hasApplied(UserEntity userEntity, GroupRequest request) {
+        OnceGroupEntity group = onceGroupService.findOnceGroupEntityByGroupId(request.groupId());
+        return userOnceGroupService.hasApplied(userEntity, group);
+    }
 }

--- a/src/main/java/com/ggang/be/api/group/onceGroup/strategy/FindOnceGroupsByUserStrategy.java
+++ b/src/main/java/com/ggang/be/api/group/onceGroup/strategy/FindOnceGroupsByUserStrategy.java
@@ -1,0 +1,29 @@
+package com.ggang.be.api.group.onceGroup.strategy;
+
+import com.ggang.be.api.group.dto.GroupRequest;
+import com.ggang.be.api.group.onceGroup.service.OnceGroupService;
+import com.ggang.be.api.group.registry.FindGroupsByUserStrategy;
+import com.ggang.be.domain.constant.GroupType;
+import com.ggang.be.global.annotation.Strategy;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@Strategy
+@RequiredArgsConstructor
+public class FindOnceGroupsByUserStrategy implements FindGroupsByUserStrategy {
+
+    private final OnceGroupService onceGroupService;
+
+    @Override
+    public GroupType getGroupType() {
+        return GroupType.ONCE;
+    }
+
+    @Override
+    public List<GroupRequest> toGroupRequests(Long userId) {
+        return onceGroupService.findByUserId(userId).stream()
+                .map(group -> new GroupRequest(group.getId(), GroupType.ONCE))
+                .toList();
+    }
+}

--- a/src/main/java/com/ggang/be/api/group/registry/CancelGroupStrategy.java
+++ b/src/main/java/com/ggang/be/api/group/registry/CancelGroupStrategy.java
@@ -8,4 +8,6 @@ public interface CancelGroupStrategy {
     boolean support(GroupType groupType);
 
     void cancelGroup(UserEntity userEntity, GroupRequest request);
+
+    boolean hasApplied(UserEntity userEntity, GroupRequest request);
 }

--- a/src/main/java/com/ggang/be/api/group/registry/FindGroupsByUserStrategy.java
+++ b/src/main/java/com/ggang/be/api/group/registry/FindGroupsByUserStrategy.java
@@ -1,0 +1,12 @@
+package com.ggang.be.api.group.registry;
+
+import com.ggang.be.api.group.dto.GroupRequest;
+import com.ggang.be.domain.constant.GroupType;
+
+import java.util.List;
+
+public interface FindGroupsByUserStrategy {
+    GroupType getGroupType();
+
+    List<GroupRequest> toGroupRequests(Long userId);
+}

--- a/src/main/java/com/ggang/be/api/group/registry/FindGroupsByUserStrategyRegistry.java
+++ b/src/main/java/com/ggang/be/api/group/registry/FindGroupsByUserStrategyRegistry.java
@@ -1,0 +1,20 @@
+package com.ggang.be.api.group.registry;
+
+import com.ggang.be.api.group.dto.GroupRequest;
+import com.ggang.be.global.annotation.Registry;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@Registry
+@RequiredArgsConstructor
+public class FindGroupsByUserStrategyRegistry {
+    private final List<FindGroupsByUserStrategy> strategies;
+
+    public List<GroupRequest> getAllGroupRequests(Long userId) {
+        return strategies.stream()
+                .flatMap(strategy -> strategy.toGroupRequests(userId).stream())
+                .toList();
+    }
+}
+

--- a/src/main/java/com/ggang/be/api/userEveryGroup/service/UserEveryGroupService.java
+++ b/src/main/java/com/ggang/be/api/userEveryGroup/service/UserEveryGroupService.java
@@ -1,9 +1,9 @@
 package com.ggang.be.api.userEveryGroup.service;
 
-import com.ggang.be.domain.group.vo.NearestGroup;
 import com.ggang.be.domain.group.dto.ReadEveryGroupMember;
 import com.ggang.be.domain.group.everyGroup.EveryGroupEntity;
 import com.ggang.be.domain.group.everyGroup.dto.ReadEveryGroup;
+import com.ggang.be.domain.group.vo.NearestGroup;
 import com.ggang.be.domain.user.UserEntity;
 import com.ggang.be.domain.userEveryGroup.dto.FillMember;
 
@@ -16,7 +16,7 @@ public interface UserEveryGroupService {
 
     NearestGroup getMyNearestGroup(UserEntity currentUser);
 
-    void isValidCommentAccess(UserEntity userEntity,final long groupId);
+    void isValidCommentAccess(UserEntity userEntity, final long groupId);
 
     void applyEveryGroup(UserEntity currentUser, EveryGroupEntity everyGroupEntity);
 
@@ -25,4 +25,6 @@ public interface UserEveryGroupService {
     void isUserInGroup(UserEntity findUserEntity, EveryGroupEntity findEveryGroupEntity);
 
     void deleteUserEveryGroup(UserEntity user);
+
+    boolean hasApplied(UserEntity user, EveryGroupEntity everyGroupEntity);
 }

--- a/src/main/java/com/ggang/be/api/userOnceGroup/service/UserOnceGroupService.java
+++ b/src/main/java/com/ggang/be/api/userOnceGroup/service/UserOnceGroupService.java
@@ -1,9 +1,9 @@
 package com.ggang.be.api.userOnceGroup.service;
 
-import com.ggang.be.domain.group.vo.NearestGroup;
 import com.ggang.be.domain.group.dto.ReadOnceGroupMember;
 import com.ggang.be.domain.group.onceGroup.OnceGroupEntity;
 import com.ggang.be.domain.group.onceGroup.dto.ReadOnceGroup;
+import com.ggang.be.domain.group.vo.NearestGroup;
 import com.ggang.be.domain.user.UserEntity;
 import com.ggang.be.domain.userEveryGroup.dto.FillMember;
 
@@ -25,4 +25,6 @@ public interface UserOnceGroupService {
     void isUserInGroup(UserEntity findUserEntity, OnceGroupEntity findOnceGroupEntity);
 
     void deleteUserOnceGroup(UserEntity user);
+
+    boolean hasApplied(UserEntity user, OnceGroupEntity onceGroupEntity);
 }

--- a/src/main/java/com/ggang/be/domain/group/everyGroup/application/EveryGroupServiceImpl.java
+++ b/src/main/java/com/ggang/be/domain/group/everyGroup/application/EveryGroupServiceImpl.java
@@ -205,6 +205,10 @@ public class EveryGroupServiceImpl implements EveryGroupService {
         return userSchool.equals(groupCreatorSchool);
     }
 
+    @Override
+    public List<EveryGroupEntity> findByUserId(Long userId) {
+        return everyGroupRepository.findByUserEntity_Id(userId);
+    }
 
     private void validateDeleteEveryGroup(UserEntity currentUser, EveryGroupEntity everyGroupEntity) {
         if (!everyGroupEntity.isHost(currentUser))

--- a/src/main/java/com/ggang/be/domain/group/onceGroup/application/OnceGroupServiceImpl.java
+++ b/src/main/java/com/ggang/be/domain/group/onceGroup/application/OnceGroupServiceImpl.java
@@ -49,7 +49,7 @@ public class OnceGroupServiceImpl implements OnceGroupService {
     @Override
     public long getOnceGroupRegisterUserId(final long groupId) {
         OnceGroupEntity entity = findIdOrThrow(groupId);
-        if(entity.getUserEntity() == null) throw new GongBaekException(ResponseError.USER_NOT_FOUND);
+        if (entity.getUserEntity() == null) throw new GongBaekException(ResponseError.USER_NOT_FOUND);
         return entity.getUserEntity().getId();
     }
 
@@ -79,7 +79,7 @@ public class OnceGroupServiceImpl implements OnceGroupService {
     @Override
     public ReadOnceGroup getActiveOnceGroups(UserEntity currentUser, Category category) {
         List<OnceGroupEntity> onceGroupEntities;
-        if(category == null) onceGroupEntities = onceGroupRepository.findAll();
+        if (category == null) onceGroupEntities = onceGroupRepository.findAll();
         else onceGroupEntities = onceGroupRepository.findAllByCategory(category);
 
         return ReadOnceGroup.of(groupVoMaker.makeOnceGroup(getRecruitingGroups(onceGroupEntities)));
@@ -91,7 +91,7 @@ public class OnceGroupServiceImpl implements OnceGroupService {
                 .collect(Collectors.toList());
     }
 
-    private List<OnceGroupEntity> getGroupsByStatus(List<OnceGroupEntity> onceGroupEntities, boolean status){
+    private List<OnceGroupEntity> getGroupsByStatus(List<OnceGroupEntity> onceGroupEntities, boolean status) {
         if (status) {
             return onceGroupEntities.stream()
                     .filter(group -> group.getStatus().isActive())
@@ -132,7 +132,7 @@ public class OnceGroupServiceImpl implements OnceGroupService {
         List<GroupCommentVo> onceGroupCommentVos = groupCommentVoMaker.makeByOnceGroup(userEntity,
                 commentEntities, onceGroupEntity);
         ReadOnceGroupCommentCommonVo vo = ReadOnceGroupCommentCommonVo.of(
-            commentCount, groupId, onceGroupEntity.getStatus());
+                commentCount, groupId, onceGroupEntity.getStatus());
 
         return ReadCommentGroup.fromOnceGroup(vo, onceGroupCommentVos);
     }
@@ -140,10 +140,10 @@ public class OnceGroupServiceImpl implements OnceGroupService {
     @Override
     @Transactional
     public OnceGroupEntity registerOnceGroup(RegisterGroupServiceRequest serviceRequest,
-        GongbaekTimeSlotEntity gongbaekTimeSlotEntity) {
+                                             GongbaekTimeSlotEntity gongbaekTimeSlotEntity) {
 
         OnceGroupEntity buildEntity = buildOnceGroupEntity(
-            serviceRequest, gongbaekTimeSlotEntity);
+                serviceRequest, gongbaekTimeSlotEntity);
 
         return onceGroupRepository.save(buildEntity);
     }
@@ -157,7 +157,7 @@ public class OnceGroupServiceImpl implements OnceGroupService {
 
     @Override
     @Transactional
-    public void validateApplyOnceGroup(UserEntity currentUser, OnceGroupEntity onceGroupEntity){
+    public void validateApplyOnceGroup(UserEntity currentUser, OnceGroupEntity onceGroupEntity) {
         validateAlreadyApplied(currentUser, onceGroupEntity);
         validateHostAccess(currentUser, onceGroupEntity);
         validateGroupFull(onceGroupEntity);
@@ -165,8 +165,8 @@ public class OnceGroupServiceImpl implements OnceGroupService {
 
     @Override
     @Transactional
-    public boolean validateCancelOnceGroup(UserEntity currentUser, OnceGroupEntity onceGroupEntity){
-        if(onceGroupEntity.isHost(currentUser))
+    public boolean validateCancelOnceGroup(UserEntity currentUser, OnceGroupEntity onceGroupEntity) {
+        if (onceGroupEntity.isHost(currentUser))
             throw new GongBaekException(ResponseError.UNAUTHORIZED_ACCESS);
 
         return onceGroupEntity.isApply(currentUser);
@@ -177,17 +177,22 @@ public class OnceGroupServiceImpl implements OnceGroupService {
     public void updateStatus() {
         List<OnceGroupEntity> onceGroupEntities = onceGroupRepository.findAllByNotStatus(Status.CLOSED);
         onceGroupEntities
-            .forEach(groupStatusUpdater::updateOnceGroup);
+                .forEach(groupStatusUpdater::updateOnceGroup);
     }
 
     @Override
     public boolean isSameSchoolOnceGroup(UserEntity currentUser, OnceGroupVo groupVo) {
         String userSchool = currentUser.getSchool().getSchoolName();
         OnceGroupEntity onceGroupEntity = findOnceGroupEntityByGroupId(
-            groupVo.groupId());
+                groupVo.groupId());
         String groupCreatorSchool = onceGroupEntity.getUserEntity().getSchool().getSchoolName();
 
         return userSchool.equals(groupCreatorSchool);
+    }
+
+    @Override
+    public List<OnceGroupEntity> findByUserId(Long userId) {
+        return onceGroupRepository.findByUserEntity_Id(userId);
     }
 
     private void validateDeleteOnceGroup(UserEntity currentUser, OnceGroupEntity onceGroupEntity) {
@@ -196,42 +201,42 @@ public class OnceGroupServiceImpl implements OnceGroupService {
     }
 
     private OnceGroupEntity buildOnceGroupEntity(RegisterGroupServiceRequest serviceRequest,
-        GongbaekTimeSlotEntity gongbaekTimeSlotEntity) {
+                                                 GongbaekTimeSlotEntity gongbaekTimeSlotEntity) {
         return OnceGroupEntity.builder()
-            .groupDate(serviceRequest.weekDate())
-            .category(serviceRequest.category())
-            .coverImg(serviceRequest.coverImg())
-            .location(serviceRequest.location())
-            .status(Status.RECRUITING)
-            .maxPeopleCount(serviceRequest.maxPeopleCount())
-            .title(serviceRequest.groupTitle())
-            .gongbaekTimeSlotEntity(gongbaekTimeSlotEntity)
-            .introduction(serviceRequest.introduction())
-            .userEntity(serviceRequest.userEntity())
-            .build();
+                .groupDate(serviceRequest.weekDate())
+                .category(serviceRequest.category())
+                .coverImg(serviceRequest.coverImg())
+                .location(serviceRequest.location())
+                .status(Status.RECRUITING)
+                .maxPeopleCount(serviceRequest.maxPeopleCount())
+                .title(serviceRequest.groupTitle())
+                .gongbaekTimeSlotEntity(gongbaekTimeSlotEntity)
+                .introduction(serviceRequest.introduction())
+                .userEntity(serviceRequest.userEntity())
+                .build();
     }
 
     private void validateAlreadyApplied(UserEntity currentUser, OnceGroupEntity onceGroupEntity) {
-        if(onceGroupEntity.isApply(currentUser)) {
+        if (onceGroupEntity.isApply(currentUser)) {
             throw new GongBaekException(ResponseError.APPLY_ALREADY_EXIST);
         }
     }
 
     private void validateHostAccess(UserEntity currentUser, OnceGroupEntity onceGroupEntity) {
-        if(onceGroupEntity.isHost(currentUser)) {
+        if (onceGroupEntity.isHost(currentUser)) {
             throw new GongBaekException(ResponseError.UNAUTHORIZED_ACCESS);
         }
     }
 
     private void validateGroupFull(OnceGroupEntity onceGroupEntity) {
-        if(onceGroupEntity.getCurrentPeopleCount() == onceGroupEntity.getMaxPeopleCount()) {
+        if (onceGroupEntity.getCurrentPeopleCount() == onceGroupEntity.getMaxPeopleCount()) {
             throw new GongBaekException(ResponseError.GROUP_ALREADY_FULL);
         }
     }
 
     private OnceGroupEntity findIdOrThrow(final long groupId) {
         return onceGroupRepository.findById(groupId).orElseThrow(
-            () -> new GongBaekException(ResponseError.GROUP_NOT_FOUND)
+                () -> new GongBaekException(ResponseError.GROUP_NOT_FOUND)
         );
     }
 }

--- a/src/main/java/com/ggang/be/domain/userEveryGroup/application/UserEveryGroupServiceImpl.java
+++ b/src/main/java/com/ggang/be/domain/userEveryGroup/application/UserEveryGroupServiceImpl.java
@@ -66,6 +66,11 @@ public class UserEveryGroupServiceImpl implements UserEveryGroupService {
     }
 
     @Override
+    public boolean hasApplied(UserEntity user, EveryGroupEntity everyGroupEntity) {
+        return userEveryGroupRepository.findByUserEntityAndEveryGroupEntity(user, everyGroupEntity).isPresent();
+    }
+
+    @Override
     public void isUserInGroup(UserEntity findUserEntity, EveryGroupEntity findEveryGroupEntity) {
         if (userEveryGroupRepository.findByUserEntityAndEveryGroupEntity(findUserEntity, findEveryGroupEntity).isEmpty()) {
             log.error("User is not in group");

--- a/src/main/java/com/ggang/be/domain/userOnceGroup/application/UserOnceGroupServiceImpl.java
+++ b/src/main/java/com/ggang/be/domain/userOnceGroup/application/UserOnceGroupServiceImpl.java
@@ -54,6 +54,11 @@ public class UserOnceGroupServiceImpl implements UserOnceGroupService {
     }
 
     @Override
+    public boolean hasApplied(UserEntity user, OnceGroupEntity onceGroupEntity) {
+        return userOnceGroupRepository.findByUserEntityAndOnceGroupEntity(user, onceGroupEntity).isPresent();
+    }
+
+    @Override
     public NearestGroup getMyNearestGroup(UserEntity currentUser) {
         List<UserOnceGroupEntity> userOnceGroupEntities = getMyOnceGroup(currentUser);
 
@@ -141,7 +146,7 @@ public class UserOnceGroupServiceImpl implements UserOnceGroupService {
         UserEntity userEntity = ue.getUserEntity();
         UserEntity hostEntity = onceGroupEntity.getUserEntity();
         boolean isHost = false;
-        if(hostEntity != null){
+        if (hostEntity != null) {
             isHost = onceGroupEntity.getUserEntity().getNickname()
                     .equals(userEntity.getNickname());
         }


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### #️⃣관련 이슈
- #90

### 🎋 작업중인 브랜치
- 작업 중인 브랜치를 알려주세요.

### 💡 작업내용
- 댓글 작성자를 신고한 사용자가 해당 작성자의 모임에 신청한 경우, 자동으로 신청을 취소하는 로직을 개선했습니다.
- 그룹 타입(Every, Once)에 따라 분기되는 로직을 Strategy Registry 패턴으로 통합하고, 중복 로직을 제거하여 확장성과 유지보수성을 높였습니다.

### 🔑 주요 변경사항
- CancelGroupStrategy, FindGroupsByUserStrategy 인터페이스 및 레지스트리 패턴 도입
- Every/OnceGroupService 내 사용자 기반 조회 로직 분리 및 책임 이전
- UserEvery/OnceGroupService 도입으로 그룹-사용자 관계 조회 책임 분리
- GroupFacade, ReportFacade에서 전략 기반 로직 적용

### 🏞 스크린샷
<img width="822" height="289" alt="image" src="https://github.com/user-attachments/assets/b7d52565-d28b-49d8-8a4e-e74aa0d34500" />

closes #90
