### PR TITLE
[fix] #94 모임 미신청자도 모임을 신고할 수 있도록 수정

### DIFF
--- a/src/main/java/com/ggang/be/api/facade/ReportFacade.java
+++ b/src/main/java/com/ggang/be/api/facade/ReportFacade.java
@@ -39,9 +39,10 @@ public class ReportFacade {
 
 
     public ResponseSuccess reportGroup(long userId, long groupId, GroupType groupType) {
-
         GroupCreatorVo groupCreator = groupFacade.findGroupCreator(groupType, groupId);
-        groupFacade.cancelMyApplication(userId, new GroupRequest(groupId, groupType));
+        GroupRequest request = GroupRequest.of(groupId, groupType);
+
+        groupFacade.cancelMyApplication(userId, request);
         reportService.reportGroup(groupId, userId, groupCreator.creatorId(), groupType);
 
         return ResponseSuccess.CREATED;

--- a/src/main/java/com/ggang/be/api/group/dto/GroupRequest.java
+++ b/src/main/java/com/ggang/be/api/group/dto/GroupRequest.java
@@ -5,4 +5,8 @@ import com.ggang.be.domain.constant.GroupType;
 public record GroupRequest(
     long groupId,
     GroupType groupType
-) { }
+) {
+    public static GroupRequest of(long groupId, GroupType groupType) {
+        return new GroupRequest(groupId, groupType);
+    }
+}

--- a/src/main/java/com/ggang/be/api/group/facade/GroupFacade.java
+++ b/src/main/java/com/ggang/be/api/group/facade/GroupFacade.java
@@ -117,7 +117,9 @@ public class GroupFacade {
                 requestDto.groupType()
         );
 
-        cancelGroupStrategy.cancelGroup(findUserEntity, requestDto);
+        if (cancelGroupStrategy.hasApplied(findUserEntity, requestDto)) {
+            cancelGroupStrategy.cancelGroup(findUserEntity, requestDto);
+        }
     }
 
     @Transactional


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### #️⃣관련 이슈
- #94 

### 🎋 작업중인 브랜치
- fix/#94

### 💡 작업내용
- 기존에는 모임에 신청하지 않은 사용자가 신고할 경우, 신청 내역이 없어 신청 취소 도중 예외가 발생했습니다.
- 이 로직을 수정하여 신청 여부와 관계없이 신고가 가능하도록 개선하였습니다.
- 불필요한 신청 여부 사전 체크 로직도 제거하고, `cancelMyApplication()` 내부에서 조건적으로 처리하도록 리팩토링했습니다.

### 🔑 주요 변경사항
- cancelMyApplication() 내에서 hasApplied() 여부 확인 후 조건적으로 취소
- reportGroup() 내 사전 분기 제거 → 로직 단순화
- 미신청자 신고 시 4048 예외 발생하지 않도록 수정

### 🏞 스크린샷
<img width="746" height="208" alt="image" src="https://github.com/user-attachments/assets/7abb1b5d-6c10-4498-b6a4-6d0d0a1b2e70" />

closes #94
