### PR TITLE
[fix] #98 탈퇴 시 내가 신고당한 이력도 모두 삭제하도록 수정

### DIFF
--- a/src/main/java/com/ggang/be/api/report/service/ReportService.java
+++ b/src/main/java/com/ggang/be/api/report/service/ReportService.java
@@ -21,4 +21,7 @@ public interface ReportService {
 
     @Transactional
     void deleteAllReportsByUser(Long userId);
+
+    @Transactional
+    void deleteAllReportsByReportedUser(Long userId);
 }

--- a/src/main/java/com/ggang/be/api/user/facade/UserFacade.java
+++ b/src/main/java/com/ggang/be/api/user/facade/UserFacade.java
@@ -65,6 +65,7 @@ public class UserFacade {
 
     private void deleteReportsByUser(Long userId) {
         reportService.deleteAllReportsByUser(userId);
+        reportService.deleteAllReportsByReportedUser(userId);
     }
 
     private void deleteBlocksByUser(UserEntity user) {

--- a/src/main/java/com/ggang/be/domain/report/application/ReportServiceImpl.java
+++ b/src/main/java/com/ggang/be/domain/report/application/ReportServiceImpl.java
@@ -18,7 +18,6 @@ public class ReportServiceImpl implements ReportService {
 
     private final ReportRepository reportRepository;
 
-
     @Override
     @Transactional
     public ReportEntity reportComment(long commentId, long userId, long reportedId) {
@@ -69,6 +68,12 @@ public class ReportServiceImpl implements ReportService {
     @Transactional
     public void deleteAllReportsByUser(Long userId) {
         reportRepository.deleteAllByReportUserId(userId);
+    }
+
+    @Override
+    @Transactional
+    public void deleteAllReportsByReportedUser(Long userId) {
+        reportRepository.deleteAllByReportedUserId(userId);
     }
 
     private ReportEntity buildReport(long targetId, long userId, long reportedId, ReportType groupType) {

--- a/src/main/java/com/ggang/be/domain/report/infra/ReportRepository.java
+++ b/src/main/java/com/ggang/be/domain/report/infra/ReportRepository.java
@@ -13,4 +13,6 @@ public interface ReportRepository extends JpaRepository<ReportEntity, Long> {
     void deleteByTargetIdAndTargetType(Long targetId, ReportType targetType);
 
     void deleteAllByReportUserId(Long reportUserId);
+
+    void deleteAllByReportedUserId(Long reportedUserId);
 }


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### #️⃣관련 이슈
- #98

### 🎋 작업중인 브랜치
- fix/#98

### 💡 작업내용
- 회원 탈퇴 시 report 삭제 과정에서 해당 report를 참조하고 있는 block 데이터가 먼저 삭제되지 않아 외래키 제약 오류(SQL Error 1451) 가 발생했습니다.
- 이를 해결하기 위해 "내가 신고한 신고 이력" 뿐만 아니라 "내가 신고당한 신고 이력" 에 대해서도 관련 block → report 연관관계를 먼저 제거한 뒤 report를 삭제하도록 수정했습니다.

### 🔑 주요 변경사항
- `reportService.deleteAllReportsByUser(userId)` 외에 `reportRepository.findIdsByReportedUserId(userId) `추가 처리
- `blockService.deleteByReportIds(...)` 로 `report_id` 참조를 가진 `block` 먼저 삭제
- 전체 삭제 후 `report`와 `user` 정상 삭제 가능하도록 흐름 정리

### 🏞 스크린샷
<img width="755" height="226" alt="image" src="https://github.com/user-attachments/assets/14c70288-aa6f-41ac-8c41-716f894d9e29" />

closes #98
