### PR TITLE
[fix] #101 회원 탈퇴 시 Block 당한 데이터 삭제 누락 수정

### DIFF
--- a/src/main/java/com/ggang/be/api/user/facade/UserFacade.java
+++ b/src/main/java/com/ggang/be/api/user/facade/UserFacade.java
@@ -70,6 +70,7 @@ public class UserFacade {
 
     private void deleteBlocksByUser(UserEntity user) {
         blockService.deleteBlocksByUser(user);
+        blockService.deleteBlocksByBlockedUserId(user.getId());
     }
 
     private void removeCommentAuthor(long userId) {

--- a/src/main/java/com/ggang/be/domain/block/application/BlockServiceImpl.java
+++ b/src/main/java/com/ggang/be/domain/block/application/BlockServiceImpl.java
@@ -50,4 +50,9 @@ public class BlockServiceImpl {
     public void deleteBlocksByUser(UserEntity user) {
         blockRepository.deleteAllByUser(user);
     }
+
+    @Transactional
+    public void deleteBlocksByBlockedUserId(Long userId) {
+        blockRepository.deleteAllByBlockedUserId(userId);
+    }
 }

--- a/src/main/java/com/ggang/be/domain/block/infra/BlockRepository.java
+++ b/src/main/java/com/ggang/be/domain/block/infra/BlockRepository.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -19,4 +20,8 @@ public interface BlockRepository extends JpaRepository<BlockEntity, Long> {
 	Optional<BlockEntity> findByReport(ReportEntity report);
 
 	void deleteAllByUser(UserEntity user);
+
+	@Modifying
+	@Query("DELETE FROM block b WHERE b.report.reportedUserId = :userId")
+	void deleteAllByBlockedUserId(Long userId);
 }


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### #️⃣관련 이슈
- #101

### 🎋 작업중인 브랜치
- fix/#101

### 💡 작업내용
- 회원 탈퇴 시 FK 제약 오류가 발생하던 문제를 해결했습니다.
- 기존 로직에서는 사용자가 차단당한 Block 데이터가 삭제되지 않아 report 삭제 시 외래키 오류가 발생했습니다.

### 🔑 주요 변경사항
- BlockServiceImpl에 차단당한 Block 삭제 로직 추가
- 회원 탈퇴 시 block → report → user 삭제 흐름에서 FK 제약 오류 해결

### 🏞 스크린샷
<img width="802" height="257" alt="image" src="https://github.com/user-attachments/assets/1bee2b50-45aa-42fd-b928-69c074e6f8ee" />

closes #101 
