### PR TITLE
[fix] #104 회원탈퇴 API에서 Block-Report 테이블 간 외래키 제약조건 위반 오류 수정

### DIFF
--- a/src/main/java/com/ggang/be/api/user/facade/UserFacade.java
+++ b/src/main/java/com/ggang/be/api/user/facade/UserFacade.java
@@ -9,15 +9,12 @@ import com.ggang.be.api.user.service.UserService;
 import com.ggang.be.api.userEveryGroup.service.UserEveryGroupService;
 import com.ggang.be.api.userOnceGroup.service.UserOnceGroupService;
 import com.ggang.be.domain.block.application.BlockServiceImpl;
-import com.ggang.be.domain.report.ReportEntity;
 import com.ggang.be.domain.report.application.ReportServiceImpl;
 import com.ggang.be.domain.user.UserEntity;
 import com.ggang.be.global.annotation.Facade;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 @Facade
 @RequiredArgsConstructor
@@ -56,30 +53,24 @@ public class UserFacade {
         log.info("== Removing gongbaek time slot user");
         removeGongbaekTimeSlotUser(userId);
 
-        log.info("== Removing blocks associated with user");
+        log.info("== Removing blocks by user");
         deleteBlocksByUser(user);
 
-        log.info("== Deleting Reports associated with user");
+        log.info("== Removing reports by user");
         deleteReportsByUser(userId);
 
         log.info("== Deleting user from repository");
         userService.deleteUser(userId);
     }
 
-    private void deleteReportsByUser(Long userId) {
-        List<ReportEntity> reportsByUser = reportService.findReports(userId);
-
-        for (ReportEntity report : reportsByUser) {
-            blockService.deleteBlocksByReport(report);
-        }
-
-        reportService.deleteAllReportsByUser(userId);
-        reportService.deleteAllReportsByReportedUser(userId);
+    private void deleteBlocksByUser(UserEntity user) {
+        blockService.deleteBlocksByBlockedUser(user);
+        blockService.deleteAllByBlockUserId(user.getId());
     }
 
-    private void deleteBlocksByUser(UserEntity user) {
-        blockService.deleteBlocksByUser(user);
-        blockService.deleteBlocksByBlockedUserId(user.getId());
+    private void deleteReportsByUser(Long userId) {
+        reportService.deleteAllReportsByUser(userId);
+        reportService.deleteAllReportsByReportedUser(userId);
     }
 
     private void removeCommentAuthor(long userId) {

--- a/src/main/java/com/ggang/be/api/user/facade/UserFacade.java
+++ b/src/main/java/com/ggang/be/api/user/facade/UserFacade.java
@@ -9,12 +9,15 @@ import com.ggang.be.api.user.service.UserService;
 import com.ggang.be.api.userEveryGroup.service.UserEveryGroupService;
 import com.ggang.be.api.userOnceGroup.service.UserOnceGroupService;
 import com.ggang.be.domain.block.application.BlockServiceImpl;
+import com.ggang.be.domain.report.ReportEntity;
 import com.ggang.be.domain.report.application.ReportServiceImpl;
 import com.ggang.be.domain.user.UserEntity;
 import com.ggang.be.global.annotation.Facade;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Facade
 @RequiredArgsConstructor
@@ -64,6 +67,12 @@ public class UserFacade {
     }
 
     private void deleteReportsByUser(Long userId) {
+        List<ReportEntity> reportsByUser = reportService.findReports(userId);
+
+        for (ReportEntity report : reportsByUser) {
+            blockService.deleteBlocksByReport(report);
+        }
+
         reportService.deleteAllReportsByUser(userId);
         reportService.deleteAllReportsByReportedUser(userId);
     }

--- a/src/main/java/com/ggang/be/domain/block/BlockEntity.java
+++ b/src/main/java/com/ggang/be/domain/block/BlockEntity.java
@@ -3,14 +3,7 @@ package com.ggang.be.domain.block;
 import com.ggang.be.domain.BaseTimeEntity;
 import com.ggang.be.domain.report.ReportEntity;
 import com.ggang.be.domain.user.UserEntity;
-
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToOne;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -21,23 +14,20 @@ import lombok.NoArgsConstructor;
 @Getter
 public class BlockEntity extends BaseTimeEntity {
 
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long id;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 
+    @OneToOne
+    private UserEntity user;
 
-	@OneToOne
-	private UserEntity user;
+    @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
+    private ReportEntity report;
 
-
-	@OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
-	private ReportEntity report;
-
-
-	@Builder
-	public BlockEntity(UserEntity user, ReportEntity report) {
-		this.user = user;
-		this.report = report;
-	}
+    @Builder
+    public BlockEntity(UserEntity user, ReportEntity report) {
+        this.user = user;
+        this.report = report;
+    }
 
 }

--- a/src/main/java/com/ggang/be/domain/block/application/BlockServiceImpl.java
+++ b/src/main/java/com/ggang/be/domain/block/application/BlockServiceImpl.java
@@ -55,4 +55,9 @@ public class BlockServiceImpl {
     public void deleteBlocksByBlockedUserId(Long userId) {
         blockRepository.deleteAllByBlockedUserId(userId);
     }
+
+    @Transactional
+    public void deleteBlocksByReport(ReportEntity report) {
+        blockRepository.deleteByReport(report);
+    }
 }

--- a/src/main/java/com/ggang/be/domain/block/application/BlockServiceImpl.java
+++ b/src/main/java/com/ggang/be/domain/block/application/BlockServiceImpl.java
@@ -47,17 +47,13 @@ public class BlockServiceImpl {
     }
 
     @Transactional
-    public void deleteBlocksByUser(UserEntity user) {
+    public void deleteBlocksByBlockedUser(UserEntity user) {
         blockRepository.deleteAllByUser(user);
     }
 
     @Transactional
-    public void deleteBlocksByBlockedUserId(Long userId) {
-        blockRepository.deleteAllByBlockedUserId(userId);
+    public void deleteAllByBlockUserId(Long userId) {
+        blockRepository.deleteAllByBlockUserId(userId);
     }
 
-    @Transactional
-    public void deleteBlocksByReport(ReportEntity report) {
-        blockRepository.deleteByReport(report);
-    }
 }

--- a/src/main/java/com/ggang/be/domain/block/infra/BlockRepository.java
+++ b/src/main/java/com/ggang/be/domain/block/infra/BlockRepository.java
@@ -23,10 +23,6 @@ public interface BlockRepository extends JpaRepository<BlockEntity, Long> {
     void deleteAllByUser(@Param("user") UserEntity user);
 
     @Modifying
-    @Query("delete from block b where b.report.reportedUserId = :userId")
-    void deleteAllByBlockedUserId(@Param("userId") Long userId);
-
-    @Modifying
-    @Query("delete from block b where b.report = :report")
-    void deleteByReport(@Param("report") ReportEntity report);
+    @Query("delete from block b where b.report.reportUserId = :userId")
+    void deleteAllByBlockUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/ggang/be/domain/block/infra/BlockRepository.java
+++ b/src/main/java/com/ggang/be/domain/block/infra/BlockRepository.java
@@ -1,27 +1,32 @@
 package com.ggang.be.domain.block.infra;
 
-import java.util.List;
-import java.util.Optional;
-
+import com.ggang.be.domain.block.BlockEntity;
+import com.ggang.be.domain.report.ReportEntity;
+import com.ggang.be.domain.user.UserEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import com.ggang.be.domain.block.BlockEntity;
-import com.ggang.be.domain.report.ReportEntity;
-import com.ggang.be.domain.user.UserEntity;
+import java.util.List;
+import java.util.Optional;
 
 public interface BlockRepository extends JpaRepository<BlockEntity, Long> {
 
-	@Query("select b.user from block b where b.id = :userId")
-	List<UserEntity> findUserId(@Param("userId") Long userId);
+    @Query("select b.user from block b where b.id = :userId")
+    List<UserEntity> findUserId(@Param("userId") Long userId);
 
-	Optional<BlockEntity> findByReport(ReportEntity report);
+    Optional<BlockEntity> findByReport(ReportEntity report);
 
-	void deleteAllByUser(UserEntity user);
+    @Modifying
+    @Query("delete from block b where b.user = :user")
+    void deleteAllByUser(@Param("user") UserEntity user);
 
-	@Modifying
-	@Query("DELETE FROM block b WHERE b.report.reportedUserId = :userId")
-	void deleteAllByBlockedUserId(Long userId);
+    @Modifying
+    @Query("delete from block b where b.report.reportedUserId = :userId")
+    void deleteAllByBlockedUserId(@Param("userId") Long userId);
+
+    @Modifying
+    @Query("delete from block b where b.report = :report")
+    void deleteByReport(@Param("report") ReportEntity report);
 }

--- a/src/main/java/com/ggang/be/domain/report/ReportEntity.java
+++ b/src/main/java/com/ggang/be/domain/report/ReportEntity.java
@@ -22,9 +22,9 @@ public class ReportEntity extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private ReportType targetType;
 
-    private Long reportUserId; // 신고자
+    private Long reportUserId;
 
-    private Long reportedUserId; // 신고 당한 사람
+    private Long reportedUserId;
 
     @Builder
     public ReportEntity(Long targetId, ReportType targetType, Long reportUserId, Long reportedUserId) {

--- a/src/main/java/com/ggang/be/domain/report/ReportEntity.java
+++ b/src/main/java/com/ggang/be/domain/report/ReportEntity.java
@@ -17,7 +17,6 @@ public class ReportEntity extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-
     private Long targetId;
 
     @Enumerated(EnumType.STRING)
@@ -27,7 +26,6 @@ public class ReportEntity extends BaseTimeEntity {
 
     private Long reportedUserId; // 신고 당한 사람
 
-
     @Builder
     public ReportEntity(Long targetId, ReportType targetType, Long reportUserId, Long reportedUserId) {
         this.targetId = targetId;
@@ -35,6 +33,5 @@ public class ReportEntity extends BaseTimeEntity {
         this.reportUserId = reportUserId;
         this.reportedUserId = reportedUserId;
     }
-
 
 }

--- a/src/main/java/com/ggang/be/domain/report/ReportEntity.java
+++ b/src/main/java/com/ggang/be/domain/report/ReportEntity.java
@@ -20,16 +20,16 @@ public class ReportEntity extends BaseTimeEntity {
     private Long targetId;
 
     @Enumerated(EnumType.STRING)
-    private ReportType reportType;
+    private ReportType targetType;
 
     private Long reportUserId;
 
     private Long reportedUserId;
 
     @Builder
-    public ReportEntity(Long targetId, ReportType reportType, Long reportUserId, Long reportedUserId) {
+    public ReportEntity(Long targetId, ReportType targetType, Long reportUserId, Long reportedUserId) {
         this.targetId = targetId;
-        this.reportType = reportType;
+        this.targetType = targetType;
         this.reportUserId = reportUserId;
         this.reportedUserId = reportedUserId;
     }

--- a/src/main/java/com/ggang/be/domain/report/application/ReportServiceImpl.java
+++ b/src/main/java/com/ggang/be/domain/report/application/ReportServiceImpl.java
@@ -40,13 +40,13 @@ public class ReportServiceImpl implements ReportService {
         return reportRepository.findByReportUserId(userId);
     }
 
-	@Override
-	public List<Long> findReportedUserIds(long reportUserId) {
-		return reportRepository.findByReportUserId(reportUserId).stream()
-				.map(ReportEntity::getReportedUserId)
-				.distinct()
-				.toList();
-	}
+    @Override
+    public List<Long> findReportedUserIds(long reportUserId) {
+        return reportRepository.findByReportUserId(reportUserId).stream()
+                .map(ReportEntity::getReportedUserId)
+                .distinct()
+                .toList();
+    }
 
     @Override
     @Transactional

--- a/src/main/java/com/ggang/be/domain/report/infra/ReportRepository.java
+++ b/src/main/java/com/ggang/be/domain/report/infra/ReportRepository.java
@@ -3,6 +3,9 @@ package com.ggang.be.domain.report.infra;
 import com.ggang.be.domain.constant.ReportType;
 import com.ggang.be.domain.report.ReportEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -12,7 +15,11 @@ public interface ReportRepository extends JpaRepository<ReportEntity, Long> {
 
     void deleteByTargetIdAndTargetType(Long targetId, ReportType targetType);
 
-    void deleteAllByReportUserId(Long reportUserId);
+    @Modifying
+    @Query("delete from report r where r.reportUserId = :reportUserId")
+    void deleteAllByReportUserId(@Param("reportUserId") Long reportUserId);
 
-    void deleteAllByReportedUserId(Long reportedUserId);
+    @Modifying
+    @Query("delete from report r where r.reportedUserId = :reportedUserId")
+    void deleteAllByReportedUserId(@Param("reportedUserId") Long reportedUserId);
 }

--- a/src/test/java/com/ggang/be/api/user/UserWithdrawalWithBlockAndReportTest.java
+++ b/src/test/java/com/ggang/be/api/user/UserWithdrawalWithBlockAndReportTest.java
@@ -75,7 +75,7 @@ class UserWithdrawalWithBlockAndReportTest {
         userFacade.deleteUser(reportedUserId);
 
         // then
-        verify(blockService).deleteBlocksByUser(reportedUser);
+        verify(blockService).deleteBlocksByBlockedUser(reportedUser);
         verify(reportService).deleteAllReportsByUser(reportedUserId);
         verify(userService).deleteUser(reportedUserId);
     }
@@ -94,7 +94,7 @@ class UserWithdrawalWithBlockAndReportTest {
         userFacade.deleteUser(reportingUserId);
 
         // then
-        verify(blockService).deleteBlocksByUser(reportingUser);
+        verify(blockService).deleteBlocksByBlockedUser(reportingUser);
         verify(reportService).deleteAllReportsByUser(reportingUserId);
         verify(userService).deleteUser(reportingUserId);
     }


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### #️⃣관련 이슈
- #104 

### 🎋 작업중인 브랜치
- fix/#104

### 💡 작업내용
- 회원탈퇴 API 호출 시 발생하는 `DataIntegrityViolationException` (SQL Error 1451)을 해결했습니다.

### 문제 상황
- `block` 테이블이 `report` 테이블을 참조하는 외래키 제약조건으로 인해 삭제 순서 문제 발생
- 사용자가 신고한 `report` 를 참조하는 `block` 들이 삭제되지 않아 `report` 삭제 시 오류 발생

### 🔑 주요 변경사항
#### **1. 삭제 순서 조정**
```java
// UserFacade.java
1. deleteBlocksByBlockedUser(user)     // 내가 차단당한 블록 삭제
2. deleteAllByBlockUserId(userId) // 내가 차단한 블록 삭제
3. deleteAllReportsByUser(userId)  // 내가 신고한 리포트 삭제
4. deleteAllReportsByReportedUser(userId) // 내가 신고당한 리포트 삭제
5. deleteUser(userId)           // 마지막 사용자 삭제
```

#### **2. 누락된 블록 삭제 로직 추가 - 내가 차단한 블록**
```java
// BlockRepository.java
@Modifying
@Query("delete from block b where b.report.reportUserId = :userId")
void deleteAllByBlockUserId(@Param("userId") Long userId);
```

#### **3. @Modifying 쿼리 적용**
```java
// BlockRepository.java, ReportRepository.java
@Modifying
@Query("delete from ...")
void deleteAllBy...();
```
---

### 🏞 스크린샷
<img width="818" height="233" alt="image" src="https://github.com/user-attachments/assets/7f2d6bcd-b978-4310-ab9d-0c7d8b8b9765" />

closes #104 
