### PR TITLE
[test] #107 신고하기 기능 및 회원탈퇴 기능 테스트

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,7 @@ dependencies {
     //data
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     runtimeOnly 'com.mysql:mysql-connector-j'
+    testRuntimeOnly 'com.h2database:h2'
 
     //jwt
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'

--- a/src/main/java/com/ggang/be/api/report/service/ReportService.java
+++ b/src/main/java/com/ggang/be/api/report/service/ReportService.java
@@ -11,8 +11,6 @@ public interface ReportService {
 
     void reportGroup(long groupId, long reportId, long reportedId, GroupType groupType);
 
-    List<ReportEntity> findReports(long userId);
-
     List<Long> findReportedUserIds(long reportUserId);
 
     void deleteReportByComment(long commentId);

--- a/src/main/java/com/ggang/be/domain/report/application/ReportServiceImpl.java
+++ b/src/main/java/com/ggang/be/domain/report/application/ReportServiceImpl.java
@@ -36,11 +36,6 @@ public class ReportServiceImpl implements ReportService {
     }
 
     @Override
-    public List<ReportEntity> findReports(long userId) {
-        return reportRepository.findByReportUserId(userId);
-    }
-
-    @Override
     public List<Long> findReportedUserIds(long reportUserId) {
         return reportRepository.findByReportUserId(reportUserId).stream()
                 .map(ReportEntity::getReportedUserId)
@@ -67,12 +62,16 @@ public class ReportServiceImpl implements ReportService {
     @Override
     @Transactional
     public void deleteAllReportsByUser(Long userId) {
+        System.out.println("Deleting reports by user: " + userId);
+        List<ReportEntity> reports = reportRepository.findByReportUserId(userId);
+        System.out.println("Found " + reports.size() + " reports to delete");
         reportRepository.deleteAllByReportUserId(userId);
     }
 
     @Override
     @Transactional
     public void deleteAllReportsByReportedUser(Long userId) {
+        System.out.println("Deleting reports by reported user: " + userId);
         reportRepository.deleteAllByReportedUserId(userId);
     }
 

--- a/src/main/java/com/ggang/be/domain/userEveryGroup/application/UserEveryGroupServiceImpl.java
+++ b/src/main/java/com/ggang/be/domain/userEveryGroup/application/UserEveryGroupServiceImpl.java
@@ -113,14 +113,16 @@ public class UserEveryGroupServiceImpl implements UserEveryGroupService {
 
     @Override
     public void deleteUserEveryGroup(UserEntity user) {
-        List<UserEveryGroupEntity> userEveryGroups = user.getUserEveryGroupEntities();
+        List<UserEveryGroupEntity> userEveryGroups = userEveryGroupRepository.findAllByUserEntity(user);
 
-        for (UserEveryGroupEntity userEveryGroup : userEveryGroups) {
-            EveryGroupEntity everyGroup = userEveryGroup.getEveryGroupEntity();
-            everyGroup.decreaseCurrentPeopleCount();
+        if (userEveryGroups != null && !userEveryGroups.isEmpty()) {
+            for (UserEveryGroupEntity userEveryGroup : userEveryGroups) {
+                EveryGroupEntity everyGroup = userEveryGroup.getEveryGroupEntity();
+                everyGroup.decreaseCurrentPeopleCount();
+            }
+
+            userEveryGroupRepository.deleteAll(userEveryGroups);
         }
-
-        userEveryGroupRepository.deleteAll(userEveryGroups);
     }
 
     private EveryGroupEntity getNearestGroup(List<EveryGroupEntity> groups) {

--- a/src/main/java/com/ggang/be/domain/userOnceGroup/application/UserOnceGroupServiceImpl.java
+++ b/src/main/java/com/ggang/be/domain/userOnceGroup/application/UserOnceGroupServiceImpl.java
@@ -113,14 +113,16 @@ public class UserOnceGroupServiceImpl implements UserOnceGroupService {
 
     @Override
     public void deleteUserOnceGroup(UserEntity user) {
-        List<UserOnceGroupEntity> userOnceGroups = user.getUserOnceGroupEntites();
+        List<UserOnceGroupEntity> userOnceGroups = userOnceGroupRepository.findAllByUserEntity(user);
 
-        for (UserOnceGroupEntity userOnceGroup : userOnceGroups) {
-            OnceGroupEntity onceGroup = userOnceGroup.getOnceGroupEntity();
-            onceGroup.decreaseCurrentPeopleCount();
+        if (userOnceGroups != null && !userOnceGroups.isEmpty()) {
+            for (UserOnceGroupEntity userOnceGroup : userOnceGroups) {
+                OnceGroupEntity onceGroup = userOnceGroup.getOnceGroupEntity();
+                onceGroup.decreaseCurrentPeopleCount();
+            }
+
+            userOnceGroupRepository.deleteAll(userOnceGroups);
         }
-
-        userOnceGroupRepository.deleteAll(userOnceGroups);
     }
 
     private OnceGroupEntity getNearestGroup(List<OnceGroupEntity> groups) {

--- a/src/test/java/com/ggang/be/api/facade/UserFacadeTest.java
+++ b/src/test/java/com/ggang/be/api/facade/UserFacadeTest.java
@@ -1,0 +1,303 @@
+package com.ggang.be.api.facade;
+
+import com.ggang.be.api.user.facade.UserFacade;
+import com.ggang.be.api.user.service.UserService;
+import com.ggang.be.domain.block.BlockEntity;
+import com.ggang.be.domain.block.infra.BlockRepository;
+import com.ggang.be.domain.comment.CommentEntity;
+import com.ggang.be.domain.comment.infra.CommentRepository;
+import com.ggang.be.domain.constant.ReportType;
+import com.ggang.be.domain.report.ReportEntity;
+import com.ggang.be.domain.report.infra.ReportRepository;
+import com.ggang.be.domain.user.UserEntity;
+import com.ggang.be.domain.user.infra.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+class UserFacadeTest {
+
+    @Autowired
+    private UserFacade userFacade;
+
+    @Autowired
+    private UserService userService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private ReportRepository reportRepository;
+
+    @Autowired
+    private BlockRepository blockRepository;
+
+    @Autowired
+    private CommentRepository commentRepository;
+
+    private UserEntity user1;
+    private UserEntity user2;
+    private UserEntity user3;
+
+    @BeforeEach
+    void setUp() {
+        // 테스트 데이터 초기화
+        userRepository.deleteAll();
+        reportRepository.deleteAll();
+        blockRepository.deleteAll();
+        commentRepository.deleteAll();
+
+        // 테스트용 사용자 생성
+        user1 = createUser("user1", "user1@test.com");
+        user2 = createUser("user2", "user2@test.com");
+        user3 = createUser("user3", "user3@test.com");
+    }
+
+    @Test
+    @DisplayName("회원탈퇴 시 신고한 댓글과 관련 블록이 모두 삭제된다")
+    @Transactional
+    void deleteUserWithReportedComments() {
+        // given
+        Long userId = user1.getId();
+        Long reportedUserId = user2.getId();
+
+        // user1이 user2의 댓글을 신고 (자동으로 블록 생성됨)
+        CommentEntity comment = createComment(user2, "신고당할 댓글");
+        ReportEntity report = createReport(comment.getId(), userId, reportedUserId, ReportType.COMMENT);
+        BlockEntity block = createBlock(report, user2);
+
+        // 다른 사용자의 신고는 남겨둠
+        CommentEntity otherComment = createComment(user3, "다른 댓글");
+        ReportEntity otherReport = createReport(otherComment.getId(), user3.getId(), user1.getId(), ReportType.COMMENT);
+
+        // when
+        userFacade.deleteUser(userId);
+
+        // then
+        // user1이 삭제되었는지 확인
+        assertThat(userRepository.findById(userId)).isEmpty();
+
+        // user1이 신고한 신고와 user1을 신고한 신고가 모두 삭제되었는지 확인
+        List<ReportEntity> reports = reportRepository.findAll();
+        System.out.println("Remaining reports: " + reports.size());
+        for (ReportEntity remainingReport : reports) {
+            System.out.println("Report - ID: " + remainingReport.getId() + ", ReportUserId: " + remainingReport.getReportUserId() + ", ReportedUserId: " + remainingReport.getReportedUserId());
+        }
+        assertThat(reports).isEmpty();
+
+        // user1이 신고한 블록이 삭제되었는지 확인
+        List<BlockEntity> blocks = blockRepository.findAll();
+        assertThat(blocks).isEmpty();
+    }
+
+    @Test
+    @DisplayName("회원탈퇴 시 신고한 그룹과 관련 블록이 모두 삭제된다")
+    @Transactional
+    void deleteUserWithReportedGroups() {
+        // given
+        Long userId = user1.getId();
+        Long reportedUserId = user2.getId();
+        Long groupId = 1L;
+
+        // user1이 user2의 그룹을 신고 (자동으로 블록 생성됨)
+        ReportEntity report = createReport(groupId, userId, reportedUserId, ReportType.ONCE_GROUP);
+        BlockEntity block = createBlock(report, user2);
+
+        // 다른 사용자의 신고는 남겨둠
+        ReportEntity otherReport = createReport(2L, user3.getId(), user1.getId(), ReportType.WEEKLY_GROUP);
+
+        // when
+        userFacade.deleteUser(userId);
+
+        // then
+        // user1이 삭제되었는지 확인
+        assertThat(userRepository.findById(userId)).isEmpty();
+
+        // user1이 신고한 신고와 user1을 신고한 신고가 모두 삭제되었는지 확인
+        List<ReportEntity> reports = reportRepository.findAll();
+        assertThat(reports).isEmpty();
+
+        // user1이 신고한 블록이 삭제되었는지 확인
+        List<BlockEntity> blocks = blockRepository.findAll();
+        assertThat(blocks).isEmpty();
+    }
+
+    @Test
+    @DisplayName("회원탈퇴 시 신고당한 사용자에 대한 모든 신고가 삭제된다")
+    @Transactional
+    void deleteUserWithReportsAgainstHim() {
+        // given
+        Long userId = user1.getId();
+        Long reporter1Id = user2.getId();
+        Long reporter2Id = user3.getId();
+
+        // user2와 user3가 user1을 신고
+        CommentEntity comment = createComment(user1, "신고당할 댓글");
+        ReportEntity report1 = createReport(comment.getId(), reporter1Id, userId, ReportType.COMMENT);
+        ReportEntity report2 = createReport(comment.getId(), reporter2Id, userId, ReportType.COMMENT);
+
+        // user1이 다른 사용자를 신고한 것은 남겨둠
+        CommentEntity otherComment = createComment(user2, "다른 댓글");
+        ReportEntity otherReport = createReport(otherComment.getId(), userId, user2.getId(), ReportType.COMMENT);
+
+        // when
+        userFacade.deleteUser(userId);
+
+        // then
+        // user1이 삭제되었는지 확인
+        assertThat(userRepository.findById(userId)).isEmpty();
+
+        // user1이 신고한 신고와 user1을 신고한 신고가 모두 삭제되었는지 확인
+        List<ReportEntity> reports = reportRepository.findAll();
+        assertThat(reports).isEmpty();
+    }
+
+    @Test
+    @DisplayName("회원탈퇴 시 작성한 댓글의 작성자가 제거된다")
+    @Transactional
+    void deleteUserWithComments() {
+        // given
+        Long userId = user1.getId();
+
+        // user1이 작성한 댓글들
+        CommentEntity comment1 = createComment(user1, "첫 번째 댓글");
+        CommentEntity comment2 = createComment(user1, "두 번째 댓글");
+
+        // 다른 사용자의 댓글은 남겨둠
+        CommentEntity otherComment = createComment(user2, "다른 사용자 댓글");
+
+        // when
+        userFacade.deleteUser(userId);
+
+        // then
+        // user1이 삭제되었는지 확인
+        assertThat(userRepository.findById(userId)).isEmpty();
+
+        // user1이 작성한 댓글들의 작성자가 제거되었는지 확인
+        List<CommentEntity> comments = commentRepository.findAll();
+        assertThat(comments).hasSize(3);
+
+        CommentEntity updatedComment1 = commentRepository.findById(comment1.getId()).orElseThrow();
+        CommentEntity updatedComment2 = commentRepository.findById(comment2.getId()).orElseThrow();
+        CommentEntity updatedOtherComment = commentRepository.findById(otherComment.getId()).orElseThrow();
+
+        assertThat(updatedComment1.getUserEntity()).isNull();
+        assertThat(updatedComment2.getUserEntity()).isNull();
+        assertThat(updatedOtherComment.getUserEntity()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("회원탈퇴 시 복합적인 신고 상황에서도 정상적으로 처리된다")
+    @Transactional
+    void deleteUserWithComplexReportScenario() {
+        // given
+        Long userId = user1.getId();
+        Long reportedUserId = user2.getId();
+
+        // user1이 user2를 신고한 상황들
+        CommentEntity comment = createComment(user2, "신고당할 댓글");
+        ReportEntity commentReport = createReport(comment.getId(), userId, reportedUserId, ReportType.COMMENT);
+        BlockEntity commentBlock = createBlock(commentReport, user2);
+
+        // user1이 user3를 신고한 상황
+        ReportEntity groupReport = createReport(1L, userId, user3.getId(), ReportType.ONCE_GROUP);
+        BlockEntity groupBlock = createBlock(groupReport, user3);
+
+        // user2가 user1을 신고한 상황
+        CommentEntity user1Comment = createComment(user1, "user1의 댓글");
+        ReportEntity user1Report = createReport(user1Comment.getId(), reportedUserId, userId, ReportType.COMMENT);
+
+        // when
+        userFacade.deleteUser(userId);
+
+        // then
+        // user1이 삭제되었는지 확인
+        assertThat(userRepository.findById(userId)).isEmpty();
+
+        // user1이 신고한 모든 신고와 user1을 신고한 모든 신고가 삭제되었는지 확인
+        List<ReportEntity> reports = reportRepository.findAll();
+        assertThat(reports).isEmpty();
+
+        // user1이 신고한 모든 블록이 삭제되었는지 확인
+        List<BlockEntity> blocks = blockRepository.findAll();
+        assertThat(blocks).isEmpty();
+    }
+
+    @Test
+    @DisplayName("회원탈퇴 시 데이터 무결성 제약에 걸리지 않는다")
+    @Transactional
+    void deleteUserWithoutIntegrityConstraintViolation() {
+        // given
+        Long userId = user1.getId();
+        Long reportedUserId = user2.getId();
+
+        // 복잡한 연관관계 생성
+        CommentEntity comment = createComment(user2, "신고당할 댓글");
+        ReportEntity report = createReport(comment.getId(), userId, reportedUserId, ReportType.COMMENT);
+        BlockEntity block = createBlock(report, user2);
+
+        // when & then
+        // 예외가 발생하지 않고 정상적으로 삭제되어야 함
+        userFacade.deleteUser(userId);
+
+        // 모든 관련 데이터가 정상적으로 삭제되었는지 확인
+        assertThat(userRepository.findById(userId)).isEmpty();
+        assertThat(reportRepository.findAll()).isEmpty();
+        assertThat(blockRepository.findAll()).isEmpty();
+    }
+
+    private UserEntity createUser(String nickname, String email) {
+        UserEntity user = UserEntity.builder()
+                .nickname(nickname)
+                .email(email)
+                .platform(com.ggang.be.domain.constant.Platform.KAKAO)
+                .platformId(nickname + "123")
+                .schoolMajorName("컴퓨터공학과")
+                .profileImg(1)
+                .enterYear(2024)
+                .mbti(com.ggang.be.domain.constant.Mbti.ENFP)
+                .gender(com.ggang.be.domain.constant.Gender.MAN)
+                .introduction("테스트 사용자")
+                .build();
+        return userRepository.save(user);
+    }
+
+    private CommentEntity createComment(UserEntity user, String body) {
+        CommentEntity comment = CommentEntity.builder()
+                .userEntity(user)
+                .body(body)
+                .isPublic(true)
+                .build();
+        return commentRepository.save(comment);
+    }
+
+    private ReportEntity createReport(Long targetId, Long reportUserId, Long reportedUserId, ReportType targetType) {
+        ReportEntity report = ReportEntity.builder()
+                .targetId(targetId)
+                .targetType(targetType)
+                .reportUserId(reportUserId)
+                .reportedUserId(reportedUserId)
+                .build();
+        return reportRepository.save(report);
+    }
+
+    private BlockEntity createBlock(ReportEntity report, UserEntity user) {
+        BlockEntity block = BlockEntity.builder()
+                .report(report)
+                .user(user)
+                .build();
+        return blockRepository.save(block);
+    }
+} 

--- a/src/test/java/com/ggang/be/domain/report/application/ReportServiceImplTest.java
+++ b/src/test/java/com/ggang/be/domain/report/application/ReportServiceImplTest.java
@@ -1,0 +1,288 @@
+package com.ggang.be.domain.report.application;
+
+import com.ggang.be.api.report.service.ReportService;
+import com.ggang.be.domain.constant.GroupType;
+import com.ggang.be.domain.constant.ReportType;
+import com.ggang.be.domain.report.ReportEntity;
+import com.ggang.be.domain.report.infra.ReportRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+class ReportServiceImplTest {
+
+    @Autowired
+    private ReportService reportService;
+
+    @Autowired
+    private ReportRepository reportRepository;
+
+    @BeforeEach
+    void setUp() {
+        reportRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("댓글 신고를 생성할 수 있다")
+    @Transactional
+    void reportComment() {
+        // given
+        long commentId = 1L;
+        long userId = 100L;
+        long reportedId = 200L;
+
+        // when
+        ReportEntity report = reportService.reportComment(commentId, userId, reportedId);
+
+        // then
+        assertThat(report.getId()).isNotNull();
+        assertThat(report.getTargetId()).isEqualTo(commentId);
+        assertThat(report.getTargetType()).isEqualTo(ReportType.COMMENT);
+        assertThat(report.getReportUserId()).isEqualTo(userId);
+        assertThat(report.getReportedUserId()).isEqualTo(reportedId);
+    }
+
+    @Test
+    @DisplayName("일회성 모임 신고를 생성할 수 있다")
+    @Transactional
+    void reportOnceGroup() {
+        // given
+        long groupId = 1L;
+        long userId = 100L;
+        long reportedId = 200L;
+        GroupType groupType = GroupType.ONCE;
+
+        // when
+        reportService.reportGroup(groupId, userId, reportedId, groupType);
+
+        // then
+        List<ReportEntity> reports = reportRepository.findAll();
+        assertThat(reports).hasSize(2); // ONCE_GROUP과 WEEKLY_GROUP 둘 다 생성됨
+        
+        // ONCE_GROUP 신고 확인
+        ReportEntity onceReport = reports.stream()
+                .filter(r -> r.getTargetType() == ReportType.ONCE_GROUP)
+                .findFirst()
+                .orElseThrow();
+        assertThat(onceReport.getTargetId()).isEqualTo(groupId);
+        assertThat(onceReport.getReportUserId()).isEqualTo(userId);
+        assertThat(onceReport.getReportedUserId()).isEqualTo(reportedId);
+        
+        // WEEKLY_GROUP 신고 확인
+        ReportEntity weeklyReport = reports.stream()
+                .filter(r -> r.getTargetType() == ReportType.WEEKLY_GROUP)
+                .findFirst()
+                .orElseThrow();
+        assertThat(weeklyReport.getTargetId()).isEqualTo(groupId);
+        assertThat(weeklyReport.getReportUserId()).isEqualTo(userId);
+        assertThat(weeklyReport.getReportedUserId()).isEqualTo(reportedId);
+    }
+
+    @Test
+    @DisplayName("다회성 그룹 신고를 생성할 수 있다")
+    @Transactional
+    void reportWeeklyGroup() {
+        // given
+        long groupId = 1L;
+        long userId = 100L;
+        long reportedId = 200L;
+        GroupType groupType = GroupType.WEEKLY;
+
+        // when
+        reportService.reportGroup(groupId, userId, reportedId, groupType);
+
+        // then
+        List<ReportEntity> reports = reportRepository.findAll();
+        assertThat(reports).hasSize(1); // WEEKLY_GROUP만 생성됨
+        
+        ReportEntity report = reports.get(0);
+        assertThat(report.getTargetId()).isEqualTo(groupId);
+        assertThat(report.getTargetType()).isEqualTo(ReportType.WEEKLY_GROUP);
+        assertThat(report.getReportUserId()).isEqualTo(userId);
+        assertThat(report.getReportedUserId()).isEqualTo(reportedId);
+    }
+
+    @Test
+    @DisplayName("사용자가 신고한 모든 사용자 ID 목록을 조회할 수 있다")
+    @Transactional
+    void findReportedUserIds() {
+        // given
+        long userId = 100L;
+        long reportedId1 = 200L;
+        long reportedId2 = 300L;
+
+        reportService.reportComment(1L, userId, reportedId1);
+        reportService.reportComment(2L, userId, reportedId1); // 같은 사용자를 또 신고
+        reportService.reportComment(3L, userId, reportedId2);
+
+        // when
+        List<Long> reportedUserIds = reportService.findReportedUserIds(userId);
+
+        // then
+        assertThat(reportedUserIds).hasSize(2);
+        assertThat(reportedUserIds).containsExactlyInAnyOrder(reportedId1, reportedId2);
+    }
+
+    /**
+     * 댓글이 삭제될 때 호출되는 메서드
+     * 댓글과 관련된 모든 신고를 삭제한다
+     */
+    @Test
+    @DisplayName("댓글 삭제 시 관련 신고도 함께 삭제된다")
+    @Transactional
+    void deleteReportByComment() {
+        // given
+        long commentId = 1L;
+        long userId = 100L;
+        long reportedId = 200L;
+
+        reportService.reportComment(commentId, userId, reportedId);
+        reportService.reportComment(2L, userId, reportedId); // 다른 댓글 신고
+
+        // when
+        reportService.deleteReportByComment(commentId);
+
+        // then
+        List<ReportEntity> reports = reportRepository.findAll();
+        assertThat(reports).hasSize(1);
+        assertThat(reports.get(0).getTargetId()).isEqualTo(2L);
+    }
+
+    /**
+     * 모임이 삭제될 때 호출되는 메서드
+     * 모임과 관련된 모든 신고를 삭제한다
+     */
+    @Test
+    @DisplayName("일회성 모임 삭제 시 신고를 삭제할 수 있다")
+    @Transactional
+    void deleteReportByOnceGroup() {
+        // given
+        long groupId = 1L;
+        long userId = 100L;
+        long reportedId = 200L;
+
+        reportService.reportGroup(groupId, userId, reportedId, GroupType.ONCE);
+        reportService.reportGroup(2L, userId, reportedId, GroupType.ONCE); // 다른 그룹 신고
+
+        // when
+        reportService.deleteReportByGroup(groupId, GroupType.ONCE);
+
+        // then
+        List<ReportEntity> reports = reportRepository.findAll();
+        assertThat(reports).hasSize(3); // 2L 그룹의 ONCE + WEEKLY 신고 2개 + groupId의 WEEKLY 신고 1개
+        assertThat(reports).allMatch(report -> report.getTargetId() != groupId || report.getTargetType() != ReportType.ONCE_GROUP);
+    }
+
+    /**
+     * 모임이 삭제될 때 호출되는 메서드
+     * 모임과 관련된 모든 신고를 삭제한다
+     */
+    @Test
+    @DisplayName("다회성 모임 삭제 시 신고를 삭제할 수 있다")
+    @Transactional
+    void deleteReportByWeeklyGroup() {
+        // given
+        long groupId = 1L;
+        long userId = 100L;
+        long reportedId = 200L;
+
+        reportService.reportGroup(groupId, userId, reportedId, GroupType.WEEKLY);
+        reportService.reportGroup(2L, userId, reportedId, GroupType.WEEKLY); // 다른 그룹 신고
+
+        // when
+        reportService.deleteReportByGroup(groupId, GroupType.WEEKLY);
+
+        // then
+        List<ReportEntity> reports = reportRepository.findAll();
+        assertThat(reports).hasSize(1);
+        assertThat(reports.get(0).getTargetId()).isEqualTo(2L);
+    }
+
+    /**
+     * 탈퇴할 때 탈퇴하는 사용자와 관련된 모임을 삭제하는 메서드
+     * 사용자와 신고한 모든 신고를 삭제한다
+     */
+    @Test
+    @DisplayName("사용자가 신고한 모든 신고를 삭제할 수 있다")
+    @Transactional
+    void deleteAllReportsByUser() {
+        // given
+        long userId = 100L;
+        long otherUserId = 200L;
+        long reportedId = 300L;
+
+        reportService.reportComment(1L, userId, reportedId);
+        reportService.reportComment(2L, userId, reportedId);
+        reportService.reportComment(3L, otherUserId, reportedId); // 다른 사용자의 신고
+
+        // when
+        reportService.deleteAllReportsByUser(userId);
+
+        // then
+        List<ReportEntity> reports = reportRepository.findAll();
+        assertThat(reports).hasSize(1);
+        assertThat(reports.get(0).getReportUserId()).isEqualTo(otherUserId);
+    }
+
+    /**
+     * 탈퇴할 때 탈퇴하는 사용자와 관련된 모임을 삭제하는 메서드
+     * 사용자가 신고당한 모든 신고를 삭제한다
+     */
+    @Test
+    @DisplayName("신고당한 사용자에 대한 모든 신고를 삭제할 수 있다")
+    @Transactional
+    void deleteAllReportsByReportedUser() {
+        // given
+        long userId1 = 100L;
+        long userId2 = 200L;
+        long reportedId = 300L;
+
+        reportService.reportComment(1L, userId1, reportedId);
+        reportService.reportComment(2L, userId2, reportedId);
+        reportService.reportComment(3L, userId1, 400L); // 다른 사용자 신고
+
+        // when
+        reportService.deleteAllReportsByReportedUser(reportedId);
+
+        // then
+        List<ReportEntity> reports = reportRepository.findAll();
+        assertThat(reports).hasSize(1);
+        assertThat(reports.get(0).getReportedUserId()).isEqualTo(400L);
+    }
+
+    @Test
+    @DisplayName("여러 사용자가 같은 사용자를 신고해도 중복 제거된 목록을 반환한다")
+    @Transactional
+    void findReportedUserIdsWithDuplicates() {
+        // given
+        long userId1 = 100L;
+        long userId2 = 200L;
+        long reportedId = 300L;
+
+        reportService.reportComment(1L, userId1, reportedId);
+        reportService.reportComment(2L, userId1, reportedId); // 같은 사용자를 또 신고
+        reportService.reportComment(3L, userId2, reportedId); // 다른 사용자가 같은 사용자 신고
+
+        // when
+        List<Long> reportedUserIds1 = reportService.findReportedUserIds(userId1);
+        List<Long> reportedUserIds2 = reportService.findReportedUserIds(userId2);
+
+        // then
+        assertThat(reportedUserIds1).hasSize(1);
+        assertThat(reportedUserIds1).containsExactly(reportedId);
+        assertThat(reportedUserIds2).hasSize(1);
+        assertThat(reportedUserIds2).containsExactly(reportedId);
+    }
+} 

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,24 @@
+spring:
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:testdb;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    username: sa
+    password: 
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: true
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect
+        format_sql: true
+        globally_quoted_identifiers: true
+        globally_quoted_identifiers_skip_column_definitions: true
+  h2:
+    console:
+      enabled: true
+
+logging:
+  level:
+    org.hibernate.SQL: DEBUG
+    org.hibernate.type.descriptor.sql: TRACE 


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### #️⃣관련 이슈
- #107 

### 🎋 작업중인 브랜치
- text/#107

### 💡 작업내용
- `ReportServiceImplTest` 를 통해 신고하기 기능을 테스트 한 후, `UserFacadeTest` 실행 중 발생한 여러 문제들을 해결하고, 회원탈퇴 로직의 안정성과 성능을 개선하는 작업을 진행했습니다. 특히 JPA의 영속성 컨텍스트, 트랜잭션 관리, 그리고 Spring Data JPA의 deleteAllBy 메서드의 동작 방식에 대한 깊은 고민과 트러블슈팅 과정을 거쳤습니다.

### 🔑 고민한 사항
#### 1. LAZY 로딩으로 인한 NullPointerException 해결
```
문제: user.getUserEveryGroupEntities() 및 user.getUserOnceGroupEntities() 호출 시 null 반환
원인: LAZY 로딩된 컬렉션이 영속성 컨텍스트 외부에서 접근되어 초기화되지 않음
해결: Repository에서 직접 조회하는 방식으로 변경 (userEveryGroupRepository.findAllByUserEntity(user))
결과: 영속성 컨텍스트 상태에 의존하지 않는 안정적인 데이터 접근 방식 적용
```

#### 2. 트랜잭션 범위 문제 해결
```
문제: deleteAllBy 메서드가 SELECT 쿼리만 실행하고 실제 DELETE 쿼리가 실행되지 않음
원인 분석: 
- deleteAllBy는 내부적으로 SELECT → 개별 DELETE 방식으로 동작
- 트랜잭션 플러시 타이밍으로 인해 User 삭제 전에 Report 삭제가 지연됨
- 영속성 컨텍스트 상태와 외래 키 제약 조건으로 인한 삭제 실패
해결: @Modifying과 @Query를 사용한 직접 DELETE 쿼리로 변경
결과: 즉시 DELETE 쿼리 실행으로 트랜잭션 범위 문제 해결
```

#### 3. 데이터 일관성 문제 고민 및 해결
```
고민: @Query 사용 시 트랜잭션 롤백으로 인한 데이터 일관성 문제 가능성
분석:
- @Query는 즉시 실행되어 트랜잭션 롤백 시 복구 불가능
- deleteAllBy는 트랜잭션 롤백 시 복구 가능하지만 트랜잭션 범위 문제 발생
결론: 현재 상황에서는 @Query 사용이 최선 (트랜잭션 범위 문제 해결이 우선)
향후 개선 방향: Domain Service 패턴 도입 및 엔티티 관계 재설계 고려
```

### 🏞 스크린샷
```
테스트 실행 결과: 모든 UserFacadeTest 통과
H2 데이터베이스 연결 성공
JPA 쿼리 로그에서 즉시 DELETE 쿼리 실행 확인
```

closes #107 
